### PR TITLE
Update hacs.json - a temporary workaround to make HACS at least work in some way

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,5 @@
   "name": "Dreame Mower",
   "render_readme": false,
   "homeassistant": "2023.6.0",
-  "zip_release": true,
-  "filename": "dreame_mower.zip"
+  "content_in_root": false
 }


### PR DESCRIPTION
_Disclaimer: I am by no means an expert in either GitHub, HA or HACS and this is my first contribution to a public GitHub repository, so please correct any mistakes I might have made._
Hello,
I have tried to download this integration using HACS (like anyone not really experienced with custom components would have done) and it failed with some error message about not being able to download `dreame-mower.zip` (as I stated in [my post in the HA Community](https://community.home-assistant.io/t/dreame-a1-a1-pro-a2-mova-600-1000-integration/749593/48?u=aaroneisele55)). I then looked up the [reference for `hacs.json` on hacs.xyz](https://www.hacs.xyz/docs/publish/start/#hacsjson) and tried to create one that at least allows users to download the latest commit.
While this worked with my fork of the repository, I know that this is not ideal and using the Releases is preferred to that. I only see the changes in this PR as a temporary workaround until a proper `hacs.json` file can be put in place, for which I do not have the knowledge to do so.

