### PR TITLE
Improved return to base behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # Other
 .DS_Store
 .vscode/launch.json
+debug/

--- a/custom_components/dreame_mower/lawn_mower.py
+++ b/custom_components/dreame_mower/lawn_mower.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import voluptuous as vol
 from typing import Final
+import logging
+import asyncio
 
 from .coordinator import DreameMowerDataUpdateCoordinator
 from .entity import DreameMowerEntity
@@ -104,6 +106,8 @@ from .const import (
     CONSUMABLE_SQUEEGEE,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 SUPPORT_DREAME = (
     LawnMowerEntityFeature.START_MOWING
     | LawnMowerEntityFeature.PAUSE
@@ -113,7 +117,7 @@ SUPPORT_DREAME = (
 STATE_CODE_TO_STATE: Final = {
     DreameMowerState.UNKNOWN: STATE_UNKNOWN,
     DreameMowerState.MOWING: LawnMowerActivity.MOWING,
-    DreameMowerState.IDLE: LawnMowerActivity.DOCKED,
+    DreameMowerState.IDLE: LawnMowerActivity.PAUSED,
     DreameMowerState.PAUSED: LawnMowerActivity.PAUSED,
     DreameMowerState.ERROR: LawnMowerActivity.ERROR,
     DreameMowerState.RETURNING: LawnMowerActivity.MOWING,
@@ -659,14 +663,30 @@ class DreameMower(DreameMowerEntity, LawnMowerEntity):
         """Pause the cleaning task."""
         await self._try_command("Unable to call pause: %s", self.device.pause)
 
-    async def async_return_to_base(self, **kwargs) -> None:
-        """Set the mower cleaner to return to the dock."""
-        await self._try_command("Unable to call stop: %s", self.device.stop)
-        await self._try_command("Unable to call return_to_base: %s", self.device.return_to_base)
-
     async def async_dock(self, **kwargs) -> None:
-        """Set the mower cleaner to return to the dock."""
-        await self._try_command("Unable to call return_to_base: %s", self.device.dock)
+        """Stop the mower if it's active, wait for it to stop, then send it to the dock."""
+        if ACTION_AVAILABILITY[DreameMowerAction.STOP.name](self.device):
+            await self._try_command("Unable to call stop: %s", self.device.stop)
+
+            try:
+                # Poll for up to 20 seconds for the mower to exit the mowing state.
+                async with asyncio.timeout(20):
+                    while True:
+                        # Manually trigger a data refresh from the device.
+                        await self.coordinator.async_request_refresh()
+
+                        # Check if the device is still in a mowing-related state.
+                        current_activity = STATE_CODE_TO_STATE.get(self.device.status.state)
+                        if current_activity != LawnMowerActivity.MOWING:
+                            break  # Exit loop once stopped
+
+                        await asyncio.sleep(2)  # Poll every 2 seconds to reduce requests
+            except TimeoutError:
+                _LOGGER.warning(
+                    "Timed out waiting for mower to stop. Proceeding with dock anyway."
+                )
+
+        await self._try_command("Unable to call dock: %s", self.device.dock)
 
     async def async_clean_zone(self, zone, repeats=1) -> None:
         await self._try_command(

--- a/tests/custom_components/dreame_mower/dreame/test_device.py
+++ b/tests/custom_components/dreame_mower/dreame/test_device.py
@@ -75,8 +75,8 @@ def test_start_mowing(device: DreameMowerDevice, mocker):
     # Assert that call_action was called with the correct action
     mock_call_action.assert_called_once_with(DreameMowerAction.START_MOWING)
 
-def test_stop_mowing(device: DreameMowerDevice, mocker):
-    """Test stopping a mowing task."""
+def test_stop_and_state_update(device: DreameMowerDevice, mocker):
+    """Test stopping a mowing task and the subsequent state update."""
     # Mock the call_action method to prevent actual network calls
     mock_call_action = mocker.patch.object(device, "call_action", return_value={"code": 0})
 
@@ -84,34 +84,22 @@ def test_stop_mowing(device: DreameMowerDevice, mocker):
     device.data[DreameMowerProperty.STATUS.value] = DreameMowerStatus.CLEANING.value
     device.data[DreameMowerProperty.TASK_STATUS.value] = DreameMowerTaskStatus.MOWING.value
     device.data[DreameMowerProperty.STATE.value] = DreameMowerState.MOWING.value
+    device.data[DreameMowerProperty.CLEANING_PAUSED.value] = False
 
     # Call the method to test
     device.stop()
 
-    # Assert that status properties were updated optimistically
+    # Assert that status properties were updated optimistically right after calling stop()
     assert device.data[DreameMowerProperty.STATUS.value] == DreameMowerStatus.STANDBY.value
     assert device.data[DreameMowerProperty.TASK_STATUS.value] == DreameMowerTaskStatus.COMPLETED.value
 
     # The 'state' property is not updated optimistically on stop.
     # It will be updated to IDLE upon receiving the next status update from the device.
-    # We assert that it remains MOWING immediately after the command.
+    # We assert that it remains MOWING immediately after the command for now.
     assert device.data[DreameMowerProperty.STATE.value] == DreameMowerState.MOWING.value
 
     # Assert that call_action was called with the correct action
     mock_call_action.assert_called_once_with(DreameMowerAction.STOP)
-
-def test_state_update_after_stop(device: DreameMowerDevice, mocker):
-    """Test that the device state is updated after stopping."""
-    # Mock the call_action method to prevent actual network calls
-    mocker.patch.object(device, "call_action", return_value={"code": 0})
-
-    # Set initial state to mowing
-    device.data[DreameMowerProperty.STATUS.value] = DreameMowerStatus.CLEANING.value
-    device.data[DreameMowerProperty.TASK_STATUS.value] = DreameMowerTaskStatus.MOWING.value
-    device.data[DreameMowerProperty.STATE.value] = DreameMowerState.MOWING.value
-
-    # Call the method to test
-    device.stop()
 
     # Simulate a property update from the device, which happens after the stop command is processed.
     # The device should now report being idle.
@@ -132,8 +120,6 @@ def test_state_update_after_stop(device: DreameMowerDevice, mocker):
 
     # Ensure the device is ready to process messages
     device._ready = True
-    # Manually trigger the message handler to simulate the update. This method is
-    # the callback that processes incoming messages from the protocol layer.
     device._message_callback({"method": "properties_changed", "params": update_payload})
 
     # Assert that the state is now updated

--- a/tests/custom_components/dreame_mower/dreame/test_device.py
+++ b/tests/custom_components/dreame_mower/dreame/test_device.py
@@ -88,17 +88,58 @@ def test_stop_mowing(device: DreameMowerDevice, mocker):
     # Call the method to test
     device.stop()
 
-    # Assert that the state was updated optimistically
+    # Assert that status properties were updated optimistically
     assert device.data[DreameMowerProperty.STATUS.value] == DreameMowerStatus.STANDBY.value
     assert device.data[DreameMowerProperty.TASK_STATUS.value] == DreameMowerTaskStatus.COMPLETED.value
 
-    # TODO: Shouldn't this be IDLE? Currently we keep it as MOWING.
-    # The state may only change to IDLE after confirmation from the hardware/cloud,
-    # or after a subsequent update. For now, we assert the optimistic update keeps it as MOWING.
+    # The 'state' property is not updated optimistically on stop.
+    # It will be updated to IDLE upon receiving the next status update from the device.
+    # We assert that it remains MOWING immediately after the command.
     assert device.data[DreameMowerProperty.STATE.value] == DreameMowerState.MOWING.value
 
     # Assert that call_action was called with the correct action
     mock_call_action.assert_called_once_with(DreameMowerAction.STOP)
+
+def test_state_update_after_stop(device: DreameMowerDevice, mocker):
+    """Test that the device state is updated after stopping."""
+    # Mock the call_action method to prevent actual network calls
+    mocker.patch.object(device, "call_action", return_value={"code": 0})
+
+    # Set initial state to mowing
+    device.data[DreameMowerProperty.STATUS.value] = DreameMowerStatus.CLEANING.value
+    device.data[DreameMowerProperty.TASK_STATUS.value] = DreameMowerTaskStatus.MOWING.value
+    device.data[DreameMowerProperty.STATE.value] = DreameMowerState.MOWING.value
+
+    # Call the method to test
+    device.stop()
+
+    # Simulate a property update from the device, which happens after the stop command is processed.
+    # The device should now report being idle.
+    # This payload mimics the format of a push notification from the cloud, which is a list of property dictionaries.
+    from custom_components.dreame_mower.dreame.types import DreameMowerPropertyMapping
+    update_payload = [
+        {
+            "siid": DreameMowerPropertyMapping[DreameMowerProperty.STATE]["siid"],
+            "piid": DreameMowerPropertyMapping[DreameMowerProperty.STATE]["piid"],
+            "value": DreameMowerState.IDLE.value,
+        },
+        {
+            "siid": DreameMowerPropertyMapping[DreameMowerProperty.STATUS]["siid"],
+            "piid": DreameMowerPropertyMapping[DreameMowerProperty.STATUS]["piid"],
+            "value": DreameMowerStatus.IDLE.value,
+        },
+    ]
+
+    # Ensure the device is ready to process messages
+    device._ready = True
+    # Manually trigger the message handler to simulate the update. This method is
+    # the callback that processes incoming messages from the protocol layer.
+    device._message_callback({"method": "properties_changed", "params": update_payload})
+
+    # Assert that the state is now updated
+    assert device.data[DreameMowerProperty.STATE.value] == DreameMowerState.IDLE.value
+    assert device.data[DreameMowerProperty.STATUS.value] == DreameMowerStatus.IDLE.value
+
 
 def test_return_to_base(device: DreameMowerDevice, mocker):
     """Test returning the mower to base."""
@@ -151,4 +192,3 @@ def test_pause(device: DreameMowerDevice, mocker):
 
     # Assert that call_action was called with the correct action
     mock_call_action.assert_called_once_with(DreameMowerAction.PAUSE)
-

--- a/tests/custom_components/dreame_mower/test_lawn_mower.py
+++ b/tests/custom_components/dreame_mower/test_lawn_mower.py
@@ -1,10 +1,15 @@
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.dreame_mower.lawn_mower import DreameMower
-from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
+from custom_components.dreame_mower.lawn_mower import DreameMower, STATE_CODE_TO_STATE
+from custom_components.dreame_mower.dreame.types import DreameMowerState, DreameMowerAction
+from custom_components.dreame_mower.dreame import ACTION_AVAILABILITY
+from homeassistant.components.lawn_mower import LawnMowerActivity
+
 
 class DummyCoordinator:
+    """A mock coordinator for testing."""
+
     def __init__(self):
         self.device = MagicMock()
         self.device.name = "Test Mower"
@@ -13,100 +18,145 @@ class DummyCoordinator:
         self.device.status = MagicMock()
         self.device.status.has_error = False
         self.device.status.paused = False
-        self.device.status.sleeping = False
-        self.device.status.charging = True
+        self.device.status.sleeping = False        
+        self.device.status.charging = False
         self.device.status.docked = False
         self.device.status.cruising = False
         self.device.status.battery_level = 80
-        self.device.status.state = 1
+        self.device.status.state = DreameMowerState.IDLE
         self.device.status.attributes = {"foo": "bar"}
         self.device.status.started = True
         self.device.status.customized_cleaning = False
         self.device.status.zone_cleaning = False
         self.device.status.spot_cleaning = False
         self.device.status.scheduled_clean = False
+        self.async_request_refresh = AsyncMock()
+
 
 @pytest.fixture
 def mower():
+    """Fixture for a DreameMower instance."""
     coordinator = DummyCoordinator()
     return DreameMower(coordinator)
 
+
+@pytest.fixture
+def bypass_try_command(mower):
+    """Fixture to bypass the _try_command wrapper for easier testing of command calls."""
+    async def fake_try_command(msg, func, *args, **kwargs):
+        await func(*args, **kwargs)
+
+    mower._try_command = fake_try_command
+    return mower
+
+
 def test_lawn_mower_properties(mower):
+    """Test the basic properties of the lawn mower entity."""
     assert mower._attr_name == "Test Mower"
     assert mower._attr_unique_id.startswith("00:11:22:33:44:55_")
     assert mower.available is True
-    assert mower.state is not None
+    assert mower.state == LawnMowerActivity.PAUSED  # Initial state is IDLE -> PAUSED
     assert isinstance(mower.extra_state_attributes, dict)
     assert mower.battery_icon.startswith("mdi:")
     assert isinstance(mower.supported_features, int)
 
 
-def test_state_and_supported_features_change(mower):
-    # Change state and supported features by updating device status
-    mower.device.status.state = 2  # DreameMowerState.IDLE
-    mower._set_attrs()
-    assert mower.state is not None
-    assert isinstance(mower.supported_features, int)
+@pytest.mark.parametrize(
+    "status_updates, expected_icon",
+    [
+        ({"has_error": True}, "mdi:alert-octagon"),
+        ({"paused": True}, "mdi:pause-circle"),
+        ({"sleeping": True}, "mdi:sleep"),
+        ({"charging": True}, "mdi:lightning-bolt-circle"),
+        ({"docked": True}, "mdi:robot-mower"),
+        ({"cruising": True}, "mdi:map-marker-path"),
+        ({}, "mdi:robot-mower"),  # Default case
+    ],
+)
+def test_icon_logic(mower, status_updates, expected_icon):
+    """Test that the icon logic correctly reflects the mower's state."""
+    # Apply the specific state for this test case
+    for key, value in status_updates.items():
+        setattr(mower.device.status, key, value)
 
-    # Simulate customized cleaning and scheduled clean
-    mower.device.status.customized_cleaning = True
-    mower.device.status.scheduled_clean = True
     mower._set_attrs()
-    assert mower._attr_fan_speed is None
-    assert isinstance(mower._attr_fan_speed_list, list)
+    assert mower.icon == expected_icon
 
-
-def test_icon_logic(mower):
-    # Error icon
-    mower.device.status.has_error = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:alert-octagon"
-
-    # Paused icon
-    mower.device.status.has_error = False
-    mower.device.status.paused = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:pause-circle"
-
-    # Sleeping icon
-    mower.device.status.paused = False
-    mower.device.status.sleeping = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:sleep"
-
-    # Charging icon
-    mower.device.status.sleeping = False
-    mower.device.status.charging = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:lightning-bolt-circle"
-
-    # Docked but not charging: default icon
-    mower.device.status.charging = False
-    mower.device.status.docked = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:robot-mower"
-
-    # Cruising icon
-    mower.device.status.docked = False
-    mower.device.status.cruising = True
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:map-marker-path"
-
-    # Default icon
-    mower.device.status.cruising = False
-    mower._set_attrs()
-    assert mower._attr_icon == "mdi:robot-mower"
 
 @pytest.mark.asyncio
-async def test_async_return_to_base_calls_stop_then_return(mower):
+async def test_async_dock_when_idle(bypass_try_command):
+    """Test that dock does not call stop when the mower is already idle."""
+    # Arrange
+    mower = bypass_try_command
     mower.device.stop = AsyncMock()
-    mower.device.return_to_base = AsyncMock()
-    async def fake_try_command(msg, func, *args, **kwargs):
-        return await func(*args, **kwargs)
-    mower._try_command = fake_try_command
+    mower.device.dock = AsyncMock()
 
-    await mower.async_return_to_base()
+    # Simulate mower is idle, making the STOP action unavailable
+    mower.device.status.state = DreameMowerState.IDLE
+    mower.device.status.started = False
+    mower.device.status.returning = False
+    mower.device.status.docking = False
+    assert not ACTION_AVAILABILITY[DreameMowerAction.STOP.name](mower.device)
 
-    # Ensure stop is called before return_to_base
-    assert mower.device.stop.call_count == 1
-    assert mower.device.return_to_base.call_count == 1
+    # Act
+    await mower.async_dock()
+
+    # Assert
+    mower.device.stop.assert_not_called()
+    mower.coordinator.async_request_refresh.assert_not_called()
+    mower.device.dock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_dock_when_mowing(bypass_try_command):
+    """Test that dock calls stop and waits for the mower to stop before returning."""
+    # Arrange
+    mower = bypass_try_command
+    mower.device.stop = AsyncMock()
+    mower.device.dock = AsyncMock()
+
+    # Simulate mower is mowing, making the STOP action available
+    mower.device.status.state = DreameMowerState.MOWING
+    mower.device.status.started = True
+    mower.device.status.returning = False
+    mower.device.status.docking = False
+    assert ACTION_AVAILABILITY[DreameMowerAction.STOP.name](mower.device)
+    assert STATE_CODE_TO_STATE.get(mower.device.status.state) == LawnMowerActivity.MOWING
+
+    # Simulate the state change during polling to exit the wait loop
+    async def refresh_side_effect():
+        mower.device.status.state = DreameMowerState.IDLE
+    mower.coordinator.async_request_refresh.side_effect = refresh_side_effect
+
+    # Act
+    await mower.async_dock()
+
+    # Assert
+    mower.device.stop.assert_called_once()
+    mower.coordinator.async_request_refresh.assert_called_once()
+    mower.device.dock.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_stop_changes_state_from_mowing(bypass_try_command):
+    """Test that calling stop correctly changes the entity's state from mowing."""
+    # Arrange: Simulate mower is mowing
+    mower = bypass_try_command
+    mower.device.status.state = DreameMowerState.MOWING
+    mower._set_attrs()
+    assert mower.state == LawnMowerActivity.MOWING
+
+    # Arrange: Patch device's stop method to simulate the state change
+    # that would be reported back by the device after stopping.
+    async def fake_stop():
+        mower.device.status.state = DreameMowerState.IDLE
+        mower._set_attrs()
+        return None
+
+    mower.device.stop = AsyncMock(side_effect=fake_stop)
+
+    # Act
+    await mower.async_stop()
+
+    # Assert: After stopping, the state should be paused.
+    # The underlying device state is 'IDLE', which maps to HA's 'PAUSED' state.
+    assert mower.state == LawnMowerActivity.PAUSED


### PR DESCRIPTION
When triggering the dock (or old: return_to_bas) command the stop call was followed immediately by dock, which was too quick as correctly pointed out in https://github.com/bhuebschen/dreame-mower/issues/35#issuecomment-3219771762
In this change we now:
a) Only call stop if the mower was actually mowing.
b) Wait for stop to have completed the state change on the device. We we max 20 sec.