### PR TITLE
Fix pool robot notifications not showing in Home Assistant (#147)

### DIFF
--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -2046,6 +2046,12 @@ class DreameSwbotDevice(DreameMowerDevice):
     # Status code reported by device when actively cleaning
     _SWBOT_STATUS_CLEANING = 4
 
+    # Notification events reported by the pool robot (siid 20).
+    # eiid 1 = cleaning task finished, eiid 2 = low battery.
+    _SWBOT_EVENT_SIID = 20
+    _SWBOT_EVENT_CLEAN_FINISH = 1
+    _SWBOT_EVENT_LOW_BATTERY = 2
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._swbot_charging: bool | None = None
@@ -2122,6 +2128,16 @@ class DreameSwbotDevice(DreameMowerDevice):
                 self._status_code = status_code
                 if old_status_code != status_code:
                     self._notify_property_change(STATUS_PROPERTY.name, status_code)
+                    # The pool robot has no "cleaning started" event, so derive
+                    # one from the status transition into the cleaning state.
+                    if (status_code == self._SWBOT_STATUS_CLEANING
+                            and old_status_code != self._SWBOT_STATUS_CLEANING):
+                        self._notify_property_change(DEVICE_CODE_INFO_PROPERTY_NAME, {
+                            "code": "CLEAN_START",
+                            "name": "Cleaning Started",
+                            "description": "The robot has started a cleaning task",
+                            "timestamp": datetime.now().isoformat(),
+                        })
                 return True
 
             if PROPERTY_1_1.matches(siid, piid):
@@ -2132,3 +2148,43 @@ class DreameSwbotDevice(DreameMowerDevice):
             _LOGGER.warning("DreameSwbotDevice: error handling property update: %s", ex)
 
         return False
+
+    def _handle_mqtt_event(self, params: dict[str, Any]) -> bool:
+        """Handle MQTT event messages for the pool robot.
+
+        The pool robot does not expose a device code property; instead it
+        reports user-facing notifications as MiOT events on siid 20:
+          eiid 1 — cleaning task finished
+          eiid 2 — low battery
+        These are mapped onto the shared device-code notification pipeline so
+        they surface as Home Assistant notifications like other devices.
+        """
+        try:
+            # Event ids may arrive as ints or numeric strings; coerce defensively.
+            siid = int(params.get("siid"))
+            eiid = int(params.get("eiid"))
+        except (TypeError, ValueError):
+            siid = eiid = None
+
+        if siid == self._SWBOT_EVENT_SIID:
+            if eiid == self._SWBOT_EVENT_CLEAN_FINISH:
+                self._notify_property_change(DEVICE_CODE_INFO_PROPERTY_NAME, {
+                    "code": "CLEAN_FINISH",
+                    "name": "Cleaning Complete",
+                    "description": "The cleaning task has finished",
+                    "timestamp": datetime.now().isoformat(),
+                })
+                return True
+
+            if eiid == self._SWBOT_EVENT_LOW_BATTERY:
+                self._notify_property_change(DEVICE_CODE_WARNING_PROPERTY_NAME, {
+                    "code": "LOW_BATTERY",
+                    "name": "Low Battery",
+                    "description": "Battery is low, retrieve the robot and charge it",
+                    "timestamp": datetime.now().isoformat(),
+                })
+                return True
+
+        # Not a pool-robot notification event: fall back to the base handler
+        # (firmware validation, mission completion, etc.).
+        return super()._handle_mqtt_event(params)

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -2159,11 +2159,13 @@ class DreameSwbotDevice(DreameMowerDevice):
         These are mapped onto the shared device-code notification pipeline so
         they surface as Home Assistant notifications like other devices.
         """
+        # Event ids may arrive as ints or numeric strings; coerce defensively.
+        siid: int | None
+        eiid: int | None
         try:
-            # Event ids may arrive as ints or numeric strings; coerce defensively.
-            siid = int(params.get("siid"))
-            eiid = int(params.get("eiid"))
-        except (TypeError, ValueError):
+            siid = int(params["siid"])
+            eiid = int(params["eiid"])
+        except (KeyError, TypeError, ValueError):
             siid = eiid = None
 
         if siid == self._SWBOT_EVENT_SIID:

--- a/custom_components/dreame_mower/manifest.json
+++ b/custom_components/dreame_mower/manifest.json
@@ -12,5 +12,5 @@
     "requests",
     "paho-mqtt>=2.0.0"
   ],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/tests/custom_components/dreame_mower/dreame/test_device_mqtt_messages.py
+++ b/tests/custom_components/dreame_mower/dreame/test_device_mqtt_messages.py
@@ -525,3 +525,85 @@ class TestDreameSwbotDeviceMqtt:
         # Fresh device has _swbot_charging=None and status_code=0
         assert pool_device._swbot_charging is None
         assert pool_device.status == "idle"
+
+    def test_pool_robot_event_clean_finish(self, pool_device):
+        """siid 20 / eiid 1 (CLEAN_FINISH) raises an info notification, not unhandled."""
+        notifications = []
+        pool_device.register_property_callback(lambda name, value: notifications.append((name, value)))
+
+        pool_device._handle_message({
+            "id": 200,
+            "method": "event_occured",
+            "params": {"siid": 20, "piid": 0, "eiid": 1, "arguments": []},
+        })
+
+        assert "unhandled_mqtt" not in [name for name, _ in notifications]
+        info = [v for name, v in notifications if name == "device_code_info"]
+        assert len(info) == 1
+        assert info[0]["code"] == "CLEAN_FINISH"
+
+    def test_pool_robot_event_low_battery(self, pool_device):
+        """siid 20 / eiid 2 (LOW_BATTERY) raises a warning notification."""
+        notifications = []
+        pool_device.register_property_callback(lambda name, value: notifications.append((name, value)))
+
+        pool_device._handle_message({
+            "id": 201,
+            "method": "event_occured",
+            "params": {"siid": 20, "piid": 0, "eiid": 2, "arguments": []},
+        })
+
+        warnings = [v for name, v in notifications if name == "device_code_warning"]
+        assert len(warnings) == 1
+        assert warnings[0]["code"] == "LOW_BATTERY"
+
+    def test_pool_robot_event_string_siid_eiid(self, pool_device):
+        """Event ids arriving as strings are coerced and still handled (defensive)."""
+        notifications = []
+        pool_device.register_property_callback(lambda name, value: notifications.append((name, value)))
+
+        pool_device._handle_message({
+            "id": 202,
+            "method": "event_occured",
+            "params": {"siid": "20", "piid": "0", "eiid": "1"},
+        })
+
+        assert any(name == "device_code_info" for name, _ in notifications)
+
+    def test_pool_robot_status_cleaning_raises_started(self, pool_device):
+        """A status transition into cleaning (4) derives a 'started' info notification."""
+        notifications = []
+        pool_device.register_property_callback(lambda name, value: notifications.append((name, value)))
+
+        pool_device._handle_message({
+            "id": 400,
+            "method": "properties_changed",
+            "params": [{"piid": 1, "siid": 2, "value": 4}],
+        })
+
+        info = [v for name, v in notifications if name == "device_code_info"]
+        assert len(info) == 1
+        assert info[0]["code"] == "CLEAN_START"
+
+    def test_pool_robot_started_not_repeated_while_cleaning(self, pool_device):
+        """The 'started' notification only fires on entry to cleaning, not on later cleaning updates."""
+        notifications = []
+        pool_device.register_property_callback(lambda name, value: notifications.append((name, value)))
+
+        cleaning = {
+            "id": 401,
+            "method": "properties_changed",
+            "params": [{"piid": 1, "siid": 2, "value": 4}],
+        }
+        idle = {
+            "id": 402,
+            "method": "properties_changed",
+            "params": [{"piid": 1, "siid": 2, "value": 1}],
+        }
+        pool_device._handle_message(cleaning)
+        pool_device._handle_message(cleaning)  # repeated, no transition
+        pool_device._handle_message(idle)
+        pool_device._handle_message(cleaning)  # re-entry, fires again
+
+        starts = [v for name, v in notifications if name == "device_code_info" and v["code"] == "CLEAN_START"]
+        assert len(starts) == 2


### PR DESCRIPTION
- Maps the pool robot's notification events onto the shared device-code notification pipeline:
  - `20:1` → **Cleaning Complete** (info)
  - `20:2` → **Low Battery** (warning)
- Derives a **Cleaning Started** notification from the status transition into the cleaning state (the firmware emits no start event), fired only on entry to cleaning.
- Falls back to the base event handler for any non-`siid 20` event, so firmware-validation and mission-completion handling are unaffected.

Fixes #147