### PR TITLE
Add cutting height support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provided "as-is" under the MIT License for personal, non-commercial use with dev
 - **Session History** - Keep track of past mowing activities
 - **Remote Control** - Start, pause, stop, and dock your mower
 - **Map Awareness** - Inspect known maps, zones, contours, and active task metadata
+- **Cutting Height** - Read and set the cutting height of the active map
 - **Battery Status** - Current battery level and charging info
 - **Mowing Progress** - Coverage percentage and session duration
 - **Do Not Disturb** - View quiet hours settings
@@ -29,6 +30,16 @@ Provided "as-is" under the MIT License for personal, non-commercial use with dev
 ## UI Elements
 
 The current release exposes map, zone, and edge selection as select entities in Home Assistant. Selecting **multiple zones or areas** at once is not yet available in the UI — use the service actions below for that.
+
+### Cutting Height
+
+The **Cutting height** number entity sets the cutting height of the **active map**, in 0.5 cm steps. The entity is only created for models whose cutting height is adjustable from software; on models with a manual height dial (for example the MOVA 600 and MOVA 1000) it is omitted.
+
+The selectable range depends on the model: most mowers go from 3 cm to 7 cm, while models with an extended range go up to 10 cm.
+
+The entity always sets the height for the whole map. To set a height for a single zone, use the `dreame_mower.set_cutting_height` service action with a `zone_id`.
+
+The mower entity exposes `cutting_height`, `zone_cutting_heights` and `mowing_preference_mode` as attributes, so automations can read back the current values and see which of the two is in effect.
 
 ### TODO: Hierarchical Mowing UI
 
@@ -87,6 +98,48 @@ target:
 data:
   spot_area_ids: [2, 4]
 ```
+
+### `dreame_mower.set_cutting_height`
+
+Set the cutting height for a whole map. Use this instead of the **Cutting height** number entity when you want to change a map that is not currently active.
+
+```yaml
+action: dreame_mower.set_cutting_height
+target:
+  entity_id: lawn_mower.your_mower
+data:
+  height: 5.5
+  map_id: 2
+```
+
+`height` is in centimeters and is rounded to the nearest 0.5 cm. `map_id` is optional and defaults to the active map; available map IDs are exposed in the mower entity's `maps` attribute.
+
+To set the height for a single zone, add `zone_id`:
+
+```yaml
+action: dreame_mower.set_cutting_height
+target:
+  entity_id: lawn_mower.your_mower
+data:
+  height: 5
+  zone_id: 3
+```
+
+Setting a zone height also switches that map to **per-zone** mowing settings, because a zone height has no effect while the map is applying one setting to everything. Every other zone keeps whatever it already had, and the map-wide height stops applying until you switch back.
+
+### `dreame_mower.set_mowing_preference_mode`
+
+Switch a map between one map-wide setting and per-zone settings. Use this to go back to a single cutting height after setting one for an individual zone.
+
+```yaml
+action: dreame_mower.set_mowing_preference_mode
+target:
+  entity_id: lawn_mower.your_mower
+data:
+  mode: map_wide
+```
+
+`mode` is `map_wide` or `per_zone`, and `map_id` is optional. The mode governs the other mowing settings as well, not only the cutting height. The mower entity's `mowing_preference_mode` attribute shows the current value.
 
 ## Installation
 

--- a/custom_components/dreame_mower/__init__.py
+++ b/custom_components/dreame_mower/__init__.py
@@ -36,6 +36,7 @@ _MOWER_PLATFORMS = (
     Platform.CAMERA,
     Platform.SELECT,
     Platform.BUTTON,
+    Platform.NUMBER,
 )
 _SWBOT_PLATFORMS = (
     Platform.SENSOR,
@@ -79,6 +80,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await coordinator.async_fetch_consumable_data()
         except Exception as ex:
             _LOGGER.warning("Initial consumable data fetch failed: %s", ex)
+
+    if coordinator.device_type != DEVICE_TYPE_SWBOT and coordinator.supports_cutting_height:
+        try:
+            await coordinator.async_fetch_cutting_heights()
+        except Exception as ex:
+            _LOGGER.warning("Initial cutting height fetch failed: %s", ex)
 
     # Store coordinator in hass data
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {

--- a/custom_components/dreame_mower/coordinator.py
+++ b/custom_components/dreame_mower/coordinator.py
@@ -35,9 +35,12 @@ from .dreame.property import (
     NOTIFICATION_DESCRIPTION_FIELD,
 )
 from .dreame.const import (
+    CURRENT_MAP_ID_PROPERTY_NAME,
     POWER_STATE_PROPERTY,
     DeviceStatus,
+    MowingPreferenceMode,
     STATUS_PROPERTY,
+    supports_cutting_height,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -294,6 +297,64 @@ class DreameMowerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self.device.current_map_id
 
     @property
+    def supports_cutting_height(self) -> bool:
+        """Return whether this model's cutting height can be set from software."""
+        return supports_cutting_height(self.device_model)
+
+    @property
+    def cutting_height(self) -> float | None:
+        """Return the current map's cutting height in cm, if known."""
+        return self.device.cutting_height
+
+    @property
+    def zone_cutting_heights(self) -> dict[int, float]:
+        """Return the per-zone cutting heights in cm known for the current map."""
+        return self.device.zone_cutting_heights
+
+    @property
+    def mowing_preference_mode(self) -> MowingPreferenceMode | None:
+        """Return whether the current map applies map-wide or per-zone preferences."""
+        return self.device.mowing_preference_mode
+
+    async def async_fetch_cutting_height(self) -> None:
+        """Read the current map's cutting height from the device."""
+        await self.device.refresh_cutting_height()
+        self.async_update_listeners()
+
+    async def async_fetch_zone_cutting_heights(self) -> dict[int, float]:
+        """Read the current map's per-zone cutting heights from the device."""
+        zone_heights = await self.device.refresh_zone_cutting_heights()
+        self.async_update_listeners()
+        return zone_heights
+
+    async def async_fetch_cutting_heights(self) -> None:
+        """Read the current map's map-wide and per-zone cutting heights."""
+        await self.device.refresh_cutting_height()
+        await self.device.refresh_zone_cutting_heights()
+        self.async_update_listeners()
+
+    async def async_set_cutting_height(
+        self,
+        height_cm: float,
+        map_id: int | None = None,
+        zone_id: int | None = None,
+    ) -> bool:
+        """Set a cutting height, defaulting to the current map and its map-wide record."""
+        updated = await self.device.set_cutting_height(height_cm, map_id, zone_id)
+        self.async_update_listeners()
+        return updated
+
+    async def async_set_mowing_preference_mode(
+        self,
+        mode: MowingPreferenceMode,
+        map_id: int | None = None,
+    ) -> bool:
+        """Choose whether a map follows its map-wide or its per-zone preferences."""
+        updated = await self.device.set_mowing_preference_mode(mode, map_id)
+        self.async_update_listeners()
+        return updated
+
+    @property
     def task_target_map_id(self) -> int | None:
         """Return the map targeted by the active task, if known."""
         return self.device.task_target_map_id
@@ -417,6 +478,10 @@ class DreameMowerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Handle device property updates and notify Home Assistant."""
         if property_name == STATUS_PROPERTY.name and int(value) == DeviceStatus.CHARGING:
             self.hass.create_task(self._async_refresh_consumables_on_charging())
+        if property_name == CURRENT_MAP_ID_PROPERTY_NAME and self.supports_cutting_height:
+            # The cutting height is stored per map, so it has to be re-read
+            # whenever the active map changes.
+            self.hass.create_task(self._async_refresh_cutting_height_on_map_change())
         self._normalize_selection_state()
 
         # Handle device code error notifications
@@ -473,6 +538,13 @@ class DreameMowerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "persistent_notification", "create",
             {"notification_id": notification_id, "title": title, "message": message},
         )
+
+    async def _async_refresh_cutting_height_on_map_change(self) -> None:
+        """Re-read the cutting heights after the active map changed."""
+        try:
+            await self.async_fetch_cutting_heights()
+        except Exception as ex:
+            _LOGGER.warning("Cutting height refresh on map change failed: %s", ex)
 
     async def _async_refresh_consumables_on_charging(self) -> None:
         """Fetch updated CMS counters when the device transitions to charging."""

--- a/custom_components/dreame_mower/dreame/const.py
+++ b/custom_components/dreame_mower/dreame/const.py
@@ -112,6 +112,80 @@ ACTION_PAUSE = ActionIdentifier(siid=5, aiid=4, name="pause")
 # Format: {m: 'a', p: <priority>, o: <opcode>, d?: <data>}
 TASK_PAYLOAD_RESUME = {"m": "a", "p": 0, "o": 5}  # continueControl
 
+# Mowing preference ("PRE") records
+#
+# The device keeps one mowing preference record per map and mowing area. The
+# record is a flat integer array whose slots carry the mowing settings shown in
+# the app (efficiency mode, cutting height, mowing direction, edge and obstacle
+# behaviour, ...). Area ID 0 addresses the map-wide record that applies to the
+# whole map; positive area IDs address per-zone overrides.
+#
+# Which of the two a map actually uses is decided by the map's preference mode,
+# read with "PREI" and written with "PREP". While a map is in MAP_WIDE mode the
+# per-zone records are stored but ignored.
+#
+# Only the slots the integration touches are named here; every other slot must
+# be written back unchanged, so a write is always a read-modify-write of the
+# record the device currently holds.
+MOWING_PREFERENCE_GLOBAL_AREA_ID = 0
+MOWING_PREFERENCE_VERSION_INDEX = 0
+MOWING_PREFERENCE_MAP_INDEX_INDEX = 1
+MOWING_PREFERENCE_AREA_ID_INDEX = 2
+MOWING_PREFERENCE_CUTTING_HEIGHT_INDEX = 4
+# Records are written with the version slot zeroed; the device assigns the
+# resulting record version itself.
+MOWING_PREFERENCE_WRITE_VERSION = 0
+# Firmware that predates the trailing record slots rejects a full-length record
+# with MOWING_PREFERENCE_STATUS_INVALID. Such a write is retried with the record
+# truncated to the layout those firmware versions accept.
+MOWING_PREFERENCE_LEGACY_LENGTH = 16
+# Per-request status reported in the "r" field of a 2:50 response.
+MOWING_PREFERENCE_STATUS_SUCCESS = 0
+MOWING_PREFERENCE_STATUS_INVALID = -3
+
+
+class MowingPreferenceMode(IntEnum):
+    """Which mowing preference records a map applies."""
+
+    MAP_WIDE = 0  # One record (area 0) governs the whole map
+    PER_ZONE = 1  # Each zone follows its own record
+
+# Cutting height limits in centimetres. The record carries the height in
+# millimetres, adjustable in half-centimetre steps.
+CUTTING_HEIGHT_STEP_CM = 0.5
+CUTTING_HEIGHT_MIN_CM = 3.0
+# Tallest cut any known model offers; the protocol-level upper bound.
+CUTTING_HEIGHT_ABSOLUTE_MAX_CM = 10.0
+# Cut height most models top out at.
+CUTTING_HEIGHT_DEFAULT_MAX_CM = 7.0
+# Model codes that offer the extended cutting height range.
+_EXTENDED_CUTTING_HEIGHT_MODELS = ("g2529", "g2541")
+# Model codes whose cutting height is not adjustable from software.
+_FIXED_CUTTING_HEIGHT_MODELS = ("g2405", "g2420", "g2552", "g2583", "yc2530")
+
+
+def _model_code(model: str) -> str:
+    """Return the bare model code of a full model identifier.
+
+    Model identifiers look like ``dreame.mower.g2408`` or ``mova.mower.g2405c``;
+    the trailing segment is the model code, optionally suffixed by a hardware
+    variant letter.
+    """
+    return model.rsplit(".", 1)[-1].strip().lower()
+
+
+def supports_cutting_height(model: str) -> bool:
+    """Return True when the model's cutting height can be set over the protocol."""
+    model_code = _model_code(model)
+    return not model_code.startswith(_FIXED_CUTTING_HEIGHT_MODELS)
+
+
+def cutting_height_max_cm(model: str) -> float:
+    """Return the tallest cut the model supports, in centimetres."""
+    if _model_code(model).startswith(_EXTENDED_CUTTING_HEIGHT_MODELS):
+        return CUTTING_HEIGHT_ABSOLUTE_MAX_CM
+    return CUTTING_HEIGHT_DEFAULT_MAX_CM
+
 # Device status mapping for STATUS_PROPERTY (2:1)
 # 
 # Charging State Refinement (via correlation with CHARGING_STATUS_PROPERTY 3:2):
@@ -208,3 +282,9 @@ FIRMWARE_INSTALL_STATE_MAPPING: dict[int, str] = {
 # Individual property names
 PROPERTY_FIRMWARE = "firmware"
 PROPERTY_TEMPERATURE = "temperature"
+
+# Derived state names reported through the device property callbacks
+CURRENT_MAP_ID_PROPERTY_NAME = "current_map_id"
+CUTTING_HEIGHT_PROPERTY_NAME = "cutting_height"
+ZONE_CUTTING_HEIGHTS_PROPERTY_NAME = "zone_cutting_heights"
+MOWING_PREFERENCE_MODE_PROPERTY_NAME = "mowing_preference_mode"

--- a/custom_components/dreame_mower/dreame/device.py
+++ b/custom_components/dreame_mower/dreame/device.py
@@ -87,6 +87,23 @@ from .const import (
     DEVICE_CODE_PROPERTY,
     PROPERTY_1_1,
     ONLINE_OFFLINE_DEBOUNCE_POLLS,
+    CURRENT_MAP_ID_PROPERTY_NAME,
+    CUTTING_HEIGHT_ABSOLUTE_MAX_CM,
+    CUTTING_HEIGHT_MIN_CM,
+    CUTTING_HEIGHT_STEP_CM,
+    CUTTING_HEIGHT_PROPERTY_NAME,
+    MOWING_PREFERENCE_AREA_ID_INDEX,
+    MOWING_PREFERENCE_CUTTING_HEIGHT_INDEX,
+    MOWING_PREFERENCE_GLOBAL_AREA_ID,
+    MOWING_PREFERENCE_LEGACY_LENGTH,
+    MOWING_PREFERENCE_MAP_INDEX_INDEX,
+    MOWING_PREFERENCE_MODE_PROPERTY_NAME,
+    MOWING_PREFERENCE_STATUS_INVALID,
+    MOWING_PREFERENCE_STATUS_SUCCESS,
+    MOWING_PREFERENCE_VERSION_INDEX,
+    MOWING_PREFERENCE_WRITE_VERSION,
+    ZONE_CUTTING_HEIGHTS_PROPERTY_NAME,
+    MowingPreferenceMode,
     DeviceStatus,
 )
 
@@ -203,6 +220,13 @@ class DreameMowerDevice:
         # Vector map from batch API
         self._vector_map: MowerVectorMap | None = None
         self._current_map_id: int | None = None
+
+        # Cutting heights of the current map, in centimetres, alongside the mode
+        # that decides which of them the mower applies. Read on demand from the
+        # mowing preference records; the device does not push them.
+        self._cutting_height: float | None = None
+        self._zone_cutting_heights: dict[int, float] = {}
+        self._mowing_preference_mode: MowingPreferenceMode | None = None
 
         # Property change callbacks
         self._property_callbacks: list[Callable[[str, Any], None]] = []
@@ -472,6 +496,21 @@ class DreameMowerDevice:
                 return map_id
 
         return None
+
+    @property
+    def cutting_height(self) -> float | None:
+        """Return the current map's cutting height in cm, if it has been read."""
+        return self._cutting_height
+
+    @property
+    def zone_cutting_heights(self) -> dict[int, float]:
+        """Return the per-zone cutting heights in cm known for the current map."""
+        return dict(self._zone_cutting_heights)
+
+    @property
+    def mowing_preference_mode(self) -> MowingPreferenceMode | None:
+        """Return whether the current map applies map-wide or per-zone preferences."""
+        return self._mowing_preference_mode
 
     @property
     def task_target_map_id(self) -> int | None:
@@ -1513,7 +1552,559 @@ class DreameMowerDevice:
 
         if self._current_map_id != current_map_id:
             self._current_map_id = current_map_id
-            self._notify_property_change("current_map_id", current_map_id)
+            self._reset_cutting_height_cache()
+            self._notify_property_change(CURRENT_MAP_ID_PROPERTY_NAME, current_map_id)
+
+        return True
+
+    def _build_get_mowing_preference_payload(
+        self,
+        map_index: int,
+        area_id: int = MOWING_PREFERENCE_GLOBAL_AREA_ID,
+    ) -> dict[str, Any]:
+        """Build the 2:50 getter payload for a mowing preference record."""
+        return {
+            "m": "g",
+            "t": "PRE",
+            "d": {
+                "idx": map_index,
+                "region": area_id,
+            },
+        }
+
+    def _build_set_mowing_preference_payload(self, record: Sequence[int]) -> dict[str, Any]:
+        """Build the 2:50 setter payload for a mowing preference record."""
+        return {
+            "m": "s",
+            "t": "PRE",
+            "d": [int(value) for value in record],
+        }
+
+    def _build_get_preference_info_payload(self, map_index: int) -> dict[str, Any]:
+        """Build the 2:50 getter payload for a map's preference overview."""
+        return {
+            "m": "g",
+            "t": "PREI",
+            "d": {
+                "idx": map_index,
+            },
+        }
+
+    def _build_set_preference_mode_payload(
+        self,
+        map_index: int,
+        mode: MowingPreferenceMode,
+    ) -> dict[str, Any]:
+        """Build the 2:50 setter payload for a map's preference mode."""
+        return {
+            "m": "s",
+            "t": "PREP",
+            "d": {
+                "idx": map_index,
+                "value": int(mode),
+            },
+        }
+
+    @staticmethod
+    def _preference_response(result: Any) -> tuple[int | None, Any]:
+        """Split a preference response into its status and payload data.
+
+        Either half is None when the response does not carry it: a write only
+        reports a status, and a malformed response reports neither.
+        """
+        if not isinstance(result, dict):
+            return None, None
+
+        if result.get("code") not in (None, 0):
+            return None, None
+
+        out_entries = result.get("out")
+        if not isinstance(out_entries, list):
+            return None, None
+
+        for out_entry in out_entries:
+            if not isinstance(out_entry, dict):
+                continue
+
+            status = out_entry.get("r")
+            normalized_status = status if isinstance(status, int) and not isinstance(status, bool) else None
+            data = out_entry.get("d")
+
+            if normalized_status is not None or data is not None:
+                return normalized_status, data
+
+        return None, None
+
+    @staticmethod
+    def _normalize_preference_record(data: Any) -> list[int] | None:
+        """Coerce a response payload into a mowing preference record."""
+        if not isinstance(data, list) or not data:
+            return None
+
+        try:
+            return [int(value) for value in data]
+        except (TypeError, ValueError):
+            return None
+
+    async def _get_mowing_preference(
+        self,
+        map_index: int,
+        area_id: int = MOWING_PREFERENCE_GLOBAL_AREA_ID,
+    ) -> list[int] | None:
+        """Read one mowing preference record, or None when it is unavailable."""
+        result = await self._send_task_payload(
+            "mowing preference read",
+            self._build_get_mowing_preference_payload(map_index, area_id),
+        )
+        status, data = self._preference_response(result)
+        record = self._normalize_preference_record(data)
+        if status not in (None, MOWING_PREFERENCE_STATUS_SUCCESS) or record is None:
+            _LOGGER.error(
+                "Failed to read the mowing preference for map index %s area %s: %s",
+                map_index,
+                area_id,
+                result,
+            )
+            return None
+
+        return record
+
+    async def _get_preference_info(
+        self,
+        map_index: int,
+    ) -> tuple[MowingPreferenceMode | None, list[int]]:
+        """Read a map's preference mode and the area IDs it holds records for."""
+        result = await self._send_task_payload(
+            "mowing preference info",
+            self._build_get_preference_info_payload(map_index),
+        )
+        status, data = self._preference_response(result)
+        if status not in (None, MOWING_PREFERENCE_STATUS_SUCCESS) or not isinstance(data, dict):
+            _LOGGER.error("Failed to read the preference info for map index %s: %s", map_index, result)
+            return None, []
+
+        mode: MowingPreferenceMode | None = None
+        try:
+            mode = MowingPreferenceMode(int(data["type"]))
+        except (KeyError, TypeError, ValueError):
+            _LOGGER.debug("Preference info for map index %s carries no known mode: %s", map_index, data)
+
+        # Each entry of the version list pairs an area ID with the version of the
+        # record the device holds for it.
+        configured_area_ids: list[int] = []
+        versions = data.get("ver")
+        if isinstance(versions, list):
+            for version_entry in versions:
+                if not isinstance(version_entry, (list, tuple)) or not version_entry:
+                    continue
+                try:
+                    configured_area_ids.append(int(version_entry[0]))
+                except (TypeError, ValueError):
+                    continue
+
+        return mode, configured_area_ids
+
+    async def _set_preference_mode(self, map_index: int, mode: MowingPreferenceMode) -> bool:
+        """Write a map's preference mode."""
+        result = await self._send_task_payload(
+            "mowing preference mode write",
+            self._build_set_preference_mode_payload(map_index, mode),
+        )
+        status, _ = self._preference_response(result)
+        if not result or status not in (None, MOWING_PREFERENCE_STATUS_SUCCESS):
+            _LOGGER.error(
+                "Failed to set the preference mode of map index %s to %s: %s",
+                map_index,
+                mode.name,
+                result,
+            )
+            return False
+
+        return True
+
+    async def _set_mowing_preference(self, record: Sequence[int]) -> bool:
+        """Write a complete mowing preference record back to the device."""
+        result = await self._send_task_payload(
+            "mowing preference write",
+            self._build_set_mowing_preference_payload(record),
+        )
+        status, _ = self._preference_response(result)
+
+        if status == MOWING_PREFERENCE_STATUS_INVALID and len(record) > MOWING_PREFERENCE_LEGACY_LENGTH:
+            _LOGGER.debug(
+                "Device rejected the full mowing preference record; retrying with %d slots",
+                MOWING_PREFERENCE_LEGACY_LENGTH,
+            )
+            result = await self._send_task_payload(
+                "mowing preference write (short record)",
+                self._build_set_mowing_preference_payload(record[:MOWING_PREFERENCE_LEGACY_LENGTH]),
+            )
+            status, _ = self._preference_response(result)
+
+        if not result or status not in (None, MOWING_PREFERENCE_STATUS_SUCCESS):
+            _LOGGER.error("Failed to write the mowing preference record %s: %s", list(record), result)
+            return False
+
+        return True
+
+    def _preference_map_index(self, map_id: int | None) -> int | None:
+        """Resolve the map index a mowing preference request targets."""
+        if map_id is None:
+            map_id = self.current_map_id
+
+        if map_id is None:
+            _LOGGER.error("No map is selected, so the mowing preference cannot be addressed")
+            return None
+
+        if not self._validate_map_id(map_id):
+            return None
+
+        return self._map_index_from_id(map_id)
+
+    def _zone_ids_for_map(self, map_id: int | None) -> list[int]:
+        """Return the zone IDs known for a map, or an empty list when unknown."""
+        if self._vector_map is None:
+            return []
+
+        if map_id is None:
+            map_id = self.current_map_id
+
+        parsed_maps = getattr(self._vector_map, "maps", None)
+        map_geometry = parsed_maps.get(map_id) if isinstance(parsed_maps, dict) else None
+        if map_geometry is None:
+            if map_id is not None and map_id != self.current_map_id:
+                return []
+            map_geometry = self._resolved_vector_map()
+
+        if map_geometry is None:
+            return []
+
+        return [int(zone.zone_id) for zone in map_geometry.zones]
+
+    def _validate_preference_zone_id(self, zone_id: int, map_id: int | None) -> bool:
+        """Return True when the zone exists on the targeted map."""
+        available_zone_ids = self._zone_ids_for_map(map_id)
+        if not available_zone_ids:
+            # No geometry for that map is loaded, so the device has to decide.
+            return True
+
+        if zone_id not in available_zone_ids:
+            _LOGGER.error(
+                "Requested unknown zone ID %s; available zones: %s",
+                zone_id,
+                sorted(available_zone_ids),
+            )
+            return False
+
+        return True
+
+    def _targets_current_map(self, map_index: int) -> bool:
+        """Return True when a map index addresses the currently selected map."""
+        current_map_id = self.current_map_id
+        return current_map_id is not None and self._map_index_from_id(current_map_id) == map_index
+
+    def _reset_cutting_height_cache(self) -> None:
+        """Drop the cached preferences, which only describe the current map."""
+        self._cutting_height = None
+        self._zone_cutting_heights = {}
+        self._mowing_preference_mode = None
+
+    def _update_cutting_height_cache(
+        self,
+        map_index: int,
+        height_cm: float,
+        zone_id: int | None = None,
+    ) -> None:
+        """Cache a cutting height when it belongs to the current map."""
+        if not self._targets_current_map(map_index):
+            return
+
+        if zone_id is not None:
+            if self._zone_cutting_heights.get(zone_id) != height_cm:
+                self._zone_cutting_heights[zone_id] = height_cm
+                self._notify_property_change(
+                    ZONE_CUTTING_HEIGHTS_PROPERTY_NAME,
+                    dict(self._zone_cutting_heights),
+                )
+            return
+
+        if height_cm != self._cutting_height:
+            self._cutting_height = height_cm
+            self._notify_property_change(CUTTING_HEIGHT_PROPERTY_NAME, height_cm)
+
+    def _update_preference_mode_cache(self, map_index: int, mode: MowingPreferenceMode) -> None:
+        """Cache a preference mode when it belongs to the current map."""
+        if not self._targets_current_map(map_index):
+            return
+
+        if mode != self._mowing_preference_mode:
+            self._mowing_preference_mode = mode
+            self._notify_property_change(MOWING_PREFERENCE_MODE_PROPERTY_NAME, mode)
+
+    @staticmethod
+    def _normalize_cutting_height(height_cm: float) -> float:
+        """Snap a requested cutting height to a settable value in centimetres."""
+        try:
+            requested_height = float(height_cm)
+        except (TypeError, ValueError) as ex:
+            raise ValueError(f"Cutting height must be a number; got {height_cm!r}") from ex
+
+        if not CUTTING_HEIGHT_MIN_CM <= requested_height <= CUTTING_HEIGHT_ABSOLUTE_MAX_CM:
+            raise ValueError(
+                f"Cutting height must be between {CUTTING_HEIGHT_MIN_CM} cm and "
+                f"{CUTTING_HEIGHT_ABSOLUTE_MAX_CM} cm; got {requested_height}"
+            )
+
+        return round(requested_height / CUTTING_HEIGHT_STEP_CM) * CUTTING_HEIGHT_STEP_CM
+
+    @staticmethod
+    def _record_cutting_height(record: Sequence[int]) -> float | None:
+        """Return the cutting height a record carries, in centimetres."""
+        if len(record) <= MOWING_PREFERENCE_CUTTING_HEIGHT_INDEX:
+            return None
+
+        return record[MOWING_PREFERENCE_CUTTING_HEIGHT_INDEX] / 10.0
+
+    def _record_for_write(
+        self,
+        record: Sequence[int],
+        map_index: int,
+        area_id: int,
+        height_cm: float,
+    ) -> list[int]:
+        """Return a copy of a record addressed at an area and carrying a height."""
+        updated_record = list(record)
+        updated_record[MOWING_PREFERENCE_VERSION_INDEX] = MOWING_PREFERENCE_WRITE_VERSION
+        updated_record[MOWING_PREFERENCE_MAP_INDEX_INDEX] = map_index
+        updated_record[MOWING_PREFERENCE_AREA_ID_INDEX] = area_id
+        updated_record[MOWING_PREFERENCE_CUTTING_HEIGHT_INDEX] = int(round(height_cm * 10))
+        return updated_record
+
+    async def refresh_cutting_height(self, map_id: int | None = None) -> float | None:
+        """Read the map-wide cutting height in cm, defaulting to the current map."""
+        map_index = self._preference_map_index(map_id)
+        if map_index is None:
+            return None
+
+        try:
+            record = await self._get_mowing_preference(map_index)
+        except Exception as ex:
+            _LOGGER.warning("Failed to read the cutting height for map index %s: %s", map_index, ex)
+            return None
+
+        if record is None:
+            return None
+
+        height_cm = self._record_cutting_height(record)
+        if height_cm is None:
+            return None
+
+        self._update_cutting_height_cache(map_index, height_cm)
+        return height_cm
+
+    async def refresh_zone_cutting_heights(self, map_id: int | None = None) -> dict[int, float]:
+        """Read the per-zone cutting heights in cm, defaulting to the current map.
+
+        Only zones the device already holds a record for are reported; the rest
+        follow the map-wide record until they are given one.
+        """
+        map_index = self._preference_map_index(map_id)
+        if map_index is None:
+            return {}
+
+        try:
+            mode, configured_area_ids = await self._get_preference_info(map_index)
+        except Exception as ex:
+            _LOGGER.warning("Failed to read the preference info for map index %s: %s", map_index, ex)
+            return {}
+
+        if mode is not None:
+            self._update_preference_mode_cache(map_index, mode)
+
+        zone_heights: dict[int, float] = {}
+        for area_id in configured_area_ids:
+            if area_id == MOWING_PREFERENCE_GLOBAL_AREA_ID:
+                continue
+
+            try:
+                record = await self._get_mowing_preference(map_index, area_id)
+            except Exception as ex:
+                _LOGGER.warning("Failed to read the cutting height of zone %s: %s", area_id, ex)
+                continue
+
+            if record is None:
+                continue
+
+            height_cm = self._record_cutting_height(record)
+            if height_cm is not None:
+                zone_heights[area_id] = height_cm
+
+        if self._targets_current_map(map_index) and zone_heights != self._zone_cutting_heights:
+            self._zone_cutting_heights = dict(zone_heights)
+            self._notify_property_change(ZONE_CUTTING_HEIGHTS_PROPERTY_NAME, dict(zone_heights))
+
+        return zone_heights
+
+    async def refresh_mowing_preference_mode(self, map_id: int | None = None) -> MowingPreferenceMode | None:
+        """Read which preference records a map applies, defaulting to the current map."""
+        map_index = self._preference_map_index(map_id)
+        if map_index is None:
+            return None
+
+        try:
+            mode, _ = await self._get_preference_info(map_index)
+        except Exception as ex:
+            _LOGGER.warning("Failed to read the preference mode for map index %s: %s", map_index, ex)
+            return None
+
+        if mode is not None:
+            self._update_preference_mode_cache(map_index, mode)
+
+        return mode
+
+    async def set_mowing_preference_mode(
+        self,
+        mode: MowingPreferenceMode,
+        map_id: int | None = None,
+    ) -> bool:
+        """Choose whether a map follows its map-wide record or its per-zone records."""
+        map_index = self._preference_map_index(map_id)
+        if map_index is None:
+            return False
+
+        try:
+            if not await self._set_preference_mode(map_index, mode):
+                return False
+        except Exception as ex:
+            _LOGGER.error("Failed to send the preference mode command: %s", ex)
+            return False
+
+        _LOGGER.info("Map index %s now applies its %s mowing preferences", map_index, mode.name)
+        self._update_preference_mode_cache(map_index, mode)
+        return True
+
+    async def _enable_per_zone_preferences(
+        self,
+        map_index: int,
+        map_id: int | None,
+        configured_area_ids: Sequence[int],
+        map_wide_record: Sequence[int] | None,
+    ) -> bool:
+        """Switch a map to its per-zone records, leaving untouched zones as they were.
+
+        A zone the device holds no record for has no settings of its own to fall
+        back on once the map stops applying its map-wide record, so every such
+        zone is first given a copy of that record.
+        """
+        map_wide_height = None if map_wide_record is None else self._record_cutting_height(map_wide_record)
+        if map_wide_record is not None and map_wide_height is not None:
+            already_configured = set(configured_area_ids)
+            for zone_id in self._zone_ids_for_map(map_id):
+                if zone_id in already_configured:
+                    continue
+
+                seeded_record = self._record_for_write(
+                    map_wide_record,
+                    map_index,
+                    zone_id,
+                    map_wide_height,
+                )
+                try:
+                    if not await self._set_mowing_preference(seeded_record):
+                        _LOGGER.warning(
+                            "Zone %s keeps no mowing preference of its own; it may fall back to device defaults",
+                            zone_id,
+                        )
+                except Exception as ex:
+                    _LOGGER.warning("Failed to seed the mowing preference of zone %s: %s", zone_id, ex)
+
+        try:
+            if not await self._set_preference_mode(map_index, MowingPreferenceMode.PER_ZONE):
+                return False
+        except Exception as ex:
+            _LOGGER.error("Failed to switch map index %s to per-zone preferences: %s", map_index, ex)
+            return False
+
+        self._update_preference_mode_cache(map_index, MowingPreferenceMode.PER_ZONE)
+        return True
+
+    async def set_cutting_height(
+        self,
+        height_cm: float,
+        map_id: int | None = None,
+        zone_id: int | None = None,
+    ) -> bool:
+        """Set a cutting height in cm, defaulting to the current map.
+
+        Without a zone the map-wide height is set. With a zone only that zone is
+        changed, and the map is switched to its per-zone records so the new
+        height actually takes effect.
+
+        The height lives in a mowing preference record alongside the remaining
+        mowing settings, so the record is read first and written back with only
+        the height slot changed. A zone that has no record of its own starts
+        from a copy of the map-wide record.
+        """
+        normalized_height = self._normalize_cutting_height(height_cm)
+
+        map_index = self._preference_map_index(map_id)
+        if map_index is None:
+            return False
+
+        if zone_id is not None and not self._validate_preference_zone_id(zone_id, map_id):
+            return False
+
+        try:
+            map_wide_record = await self._get_mowing_preference(map_index)
+            configured_area_ids: list[int] = []
+            mode: MowingPreferenceMode | None = None
+            base_record = map_wide_record
+
+            if zone_id is not None:
+                mode, configured_area_ids = await self._get_preference_info(map_index)
+                if zone_id in configured_area_ids:
+                    base_record = await self._get_mowing_preference(map_index, zone_id) or map_wide_record
+        except Exception as ex:
+            _LOGGER.error("Failed to read the mowing preference before setting the cutting height: %s", ex)
+            return False
+
+        if base_record is None or self._record_cutting_height(base_record) is None:
+            _LOGGER.error(
+                "Cannot set the cutting height for map index %s without its mowing preference record",
+                map_index,
+            )
+            return False
+
+        area_id = MOWING_PREFERENCE_GLOBAL_AREA_ID if zone_id is None else zone_id
+        updated_record = self._record_for_write(base_record, map_index, area_id, normalized_height)
+
+        try:
+            if not await self._set_mowing_preference(updated_record):
+                return False
+        except Exception as ex:
+            _LOGGER.error("Failed to send the cutting height command: %s", ex)
+            return False
+
+        if zone_id is None:
+            _LOGGER.info("Cutting height set to %s cm for map index %s", normalized_height, map_index)
+            self._update_cutting_height_cache(map_index, normalized_height)
+            return True
+
+        _LOGGER.info(
+            "Cutting height set to %s cm for zone %s of map index %s",
+            normalized_height,
+            zone_id,
+            map_index,
+        )
+        self._update_cutting_height_cache(map_index, normalized_height, zone_id=zone_id)
+
+        if mode != MowingPreferenceMode.PER_ZONE:
+            await self._enable_per_zone_preferences(
+                map_index,
+                map_id,
+                [*configured_area_ids, zone_id],
+                map_wide_record,
+            )
 
         return True
 
@@ -1834,8 +2425,9 @@ class DreameMowerDevice:
             return False
 
         self._current_map_id = map_id
+        self._reset_cutting_height_cache()
         _LOGGER.info("Current map switched to map ID %s (index %s)", map_id, map_index)
-        self._notify_property_change("current_map_id", map_id)
+        self._notify_property_change(CURRENT_MAP_ID_PROPERTY_NAME, map_id)
         return True
 
     def _validate_contour_ids(self, contour_ids: list[list[int]]) -> bool:

--- a/custom_components/dreame_mower/lawn_mower.py
+++ b/custom_components/dreame_mower/lawn_mower.py
@@ -21,9 +21,18 @@ from .const import DATA_COORDINATOR, DOMAIN
 from .coordinator import DreameMowerCoordinator
 from .dreame.device import MowingMode
 from .entity import DreameMowerEntity
-from .dreame.const import STATUS_PROPERTY, map_status_to_activity
+from .dreame.const import (
+    CUTTING_HEIGHT_ABSOLUTE_MAX_CM,
+    CUTTING_HEIGHT_MIN_CM,
+    MowingPreferenceMode,
+    STATUS_PROPERTY,
+    map_status_to_activity,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Service-facing names for the mowing preference modes, e.g. "map_wide".
+_MOWING_PREFERENCE_MODES = {mode.name.lower(): mode for mode in MowingPreferenceMode}
 
 # Basic feature support for minimal implementation
 MINIMAL_SUPPORT_FEATURES = (
@@ -55,6 +64,26 @@ async def async_setup_entry(
         "start_spot_mowing",
         {vol.Required("spot_area_ids"): [vol.Coerce(int)]},
         "async_start_spot_mowing",
+    )
+    platform.async_register_entity_service(
+        "set_cutting_height",
+        {
+            vol.Required("height"): vol.All(
+                vol.Coerce(float),
+                vol.Range(min=CUTTING_HEIGHT_MIN_CM, max=CUTTING_HEIGHT_ABSOLUTE_MAX_CM),
+            ),
+            vol.Optional("map_id"): vol.Coerce(int),
+            vol.Optional("zone_id"): vol.Coerce(int),
+        },
+        "async_set_cutting_height",
+    )
+    platform.async_register_entity_service(
+        "set_mowing_preference_mode",
+        {
+            vol.Required("mode"): vol.In(_MOWING_PREFERENCE_MODES),
+            vol.Optional("map_id"): vol.Coerce(int),
+        },
+        "async_set_mowing_preference_mode",
     )
 
     entity = DreameMowerLawnMower(coordinator)
@@ -178,6 +207,40 @@ class DreameMowerLawnMower(DreameMowerEntity, LawnMowerEntity):
         if not await self.coordinator.device.start_mowing_spots(spot_area_ids):
             raise HomeAssistantError(f"Failed to start spot mowing for spot IDs: {spot_area_ids}")
 
+    async def async_set_cutting_height(
+        self,
+        height: float,
+        map_id: int | None = None,
+        zone_id: int | None = None,
+    ) -> None:
+        """Set the cutting height for a map, or for a single zone of it."""
+        self._assert_cutting_height_supported()
+
+        try:
+            updated = await self.coordinator.async_set_cutting_height(height, map_id, zone_id)
+        except ValueError as ex:
+            raise HomeAssistantError(str(ex)) from ex
+
+        if not updated:
+            target = "the map" if zone_id is None else f"zone {zone_id}"
+            raise HomeAssistantError(f"Failed to set the cutting height of {target} to {height} cm")
+
+    async def async_set_mowing_preference_mode(self, mode: str, map_id: int | None = None) -> None:
+        """Choose whether a map follows one set of mowing settings or per-zone ones."""
+        self._assert_cutting_height_supported()
+
+        if not await self.coordinator.async_set_mowing_preference_mode(
+            _MOWING_PREFERENCE_MODES[mode], map_id
+        ):
+            raise HomeAssistantError(f"Failed to switch the mowing preferences to {mode}")
+
+    def _assert_cutting_height_supported(self) -> None:
+        """Raise when the model has no software-adjustable cutting height."""
+        if not self.coordinator.supports_cutting_height:
+            raise HomeAssistantError(
+                f"{self.coordinator.device_model} has no software-adjustable cutting height"
+            )
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes including available zones and contours."""
@@ -197,6 +260,15 @@ class DreameMowerLawnMower(DreameMowerEntity, LawnMowerEntity):
             attributes["current_map_id"] = current_map_id
         if task_target_map_id is not None:
             attributes["task_target_map_id"] = task_target_map_id
+        if self.coordinator.supports_cutting_height:
+            # Exposed so automations can read back what set_cutting_height did and
+            # tell whether the map-wide height is the one currently in effect.
+            attributes["cutting_height"] = self.coordinator.cutting_height
+            attributes["zone_cutting_heights"] = self.coordinator.zone_cutting_heights
+            mowing_preference_mode = self.coordinator.mowing_preference_mode
+            attributes["mowing_preference_mode"] = (
+                None if mowing_preference_mode is None else mowing_preference_mode.name.lower()
+            )
         attributes["selected_mowing_mode"] = self.coordinator.selected_mowing_mode.value
         if self.coordinator.selected_contour_id is not None:
             attributes["selected_contour_id"] = self.coordinator.selected_contour_id

--- a/custom_components/dreame_mower/number.py
+++ b/custom_components/dreame_mower/number.py
@@ -1,0 +1,67 @@
+"""Number entities for Dreame Mower."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfLength
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DATA_COORDINATOR, DOMAIN
+from .coordinator import DreameMowerCoordinator
+from .dreame.const import (
+    CUTTING_HEIGHT_MIN_CM,
+    CUTTING_HEIGHT_STEP_CM,
+    cutting_height_max_cm,
+)
+from .entity import DreameMowerEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Dreame Mower numbers from a config entry."""
+    coordinator: DreameMowerCoordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+
+    if not coordinator.supports_cutting_height:
+        _LOGGER.debug(
+            "Skipping the cutting height entity: model %s has no software-adjustable cutting height",
+            coordinator.device_model,
+        )
+        return
+
+    async_add_entities([DreameMowerCuttingHeightNumber(coordinator)])
+
+
+class DreameMowerCuttingHeightNumber(DreameMowerEntity, NumberEntity):
+    """Number entity for the cutting height of the active map."""
+
+    _attr_translation_key = "cutting_height"
+    _attr_icon = "mdi:arrow-up-down"
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement = UnitOfLength.CENTIMETERS
+    _attr_native_min_value = CUTTING_HEIGHT_MIN_CM
+    _attr_native_step = CUTTING_HEIGHT_STEP_CM
+
+    def __init__(self, coordinator: DreameMowerCoordinator) -> None:
+        """Initialize the cutting height entity."""
+        super().__init__(coordinator, "cutting_height")
+        self._attr_native_max_value = cutting_height_max_cm(coordinator.device_model)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the cutting height of the active map, if it is known."""
+        return self.coordinator.cutting_height
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the cutting height for the active map."""
+        if not await self.coordinator.async_set_cutting_height(value):
+            raise HomeAssistantError(f"Failed to set the cutting height to {value} cm")

--- a/custom_components/dreame_mower/services.yaml
+++ b/custom_components/dreame_mower/services.yaml
@@ -42,3 +42,72 @@ start_spot_mowing:
       description: List of spot area IDs to mow, for example [2, 4].
       required: true
       example: [2, 4]
+
+set_cutting_height:
+  name: Set cutting height
+  description: >-
+    Set the cutting height for a whole map, or for a single zone of it. Not
+    every model supports adjusting the cutting height, and the range depends on
+    the model.
+  target:
+    entity:
+      integration: dreame_mower
+      domain: lawn_mower
+  fields:
+    height:
+      name: Cutting height
+      description: Cutting height in centimeters, in steps of 0.5 cm.
+      required: true
+      example: 5
+      selector:
+        number:
+          min: 3
+          max: 10
+          step: 0.5
+          unit_of_measurement: cm
+    map_id:
+      name: Map ID
+      description: >-
+        Map to change. Defaults to the active map. Available map IDs are exposed
+        in the mower entity's maps attribute once the map has been fetched.
+      required: false
+      example: 2
+    zone_id:
+      name: Zone ID
+      description: >-
+        Zone to change instead of the whole map. Setting a zone also switches
+        the map to per-zone mowing settings, so the other zones keep their own
+        heights and the map-wide height stops applying. Available zone IDs are
+        exposed in the mower entity's zones attribute.
+      required: false
+      example: 3
+
+set_mowing_preference_mode:
+  name: Set mowing preference mode
+  description: >-
+    Choose whether a map applies one set of mowing settings or per-zone
+    settings. Use this to return to a single map-wide cutting height after
+    setting one for an individual zone. The mode covers the other mowing
+    settings too, not only the cutting height.
+  target:
+    entity:
+      integration: dreame_mower
+      domain: lawn_mower
+  fields:
+    mode:
+      name: Mode
+      description: Whether the map follows its map-wide or its per-zone settings.
+      required: true
+      example: map_wide
+      selector:
+        select:
+          options:
+            - label: One setting for the whole map
+              value: map_wide
+            - label: A setting per zone
+              value: per_zone
+    map_id:
+      name: Map ID
+      description: Map to change. Defaults to the active map.
+      required: false
+      example: 2

--- a/custom_components/dreame_mower/translations/de.json
+++ b/custom_components/dreame_mower/translations/de.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Andocken ohne Aufgabe zu stoppen"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Schnitthöhe"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/en.json
+++ b/custom_components/dreame_mower/translations/en.json
@@ -162,6 +162,11 @@
       "map_camera": {
         "name": "Map"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Cutting Height"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/es.json
+++ b/custom_components/dreame_mower/translations/es.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Acoplar sin detener la tarea"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Altura de corte"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/fr.json
+++ b/custom_components/dreame_mower/translations/fr.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Revenir à la base sans arrêter la tâche"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Hauteur de coupe"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/hu.json
+++ b/custom_components/dreame_mower/translations/hu.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Dokkolás feladat leállítása nélkül"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Vágási magasság"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/it.json
+++ b/custom_components/dreame_mower/translations/it.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Torna alla base senza fermare il compito"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Altezza di taglio"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/nl.json
+++ b/custom_components/dreame_mower/translations/nl.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Dokken zonder taak te stoppen"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Maaihoogte"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/pl.json
+++ b/custom_components/dreame_mower/translations/pl.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Dokowanie bez zatrzymywania zadania"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Wysokość koszenia"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/pt-BR.json
+++ b/custom_components/dreame_mower/translations/pt-BR.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Retornar à base sem parar a tarefa"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Altura de corte"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/pt.json
+++ b/custom_components/dreame_mower/translations/pt.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Regressar à base sem parar a tarefa"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Altura de corte"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/ru.json
+++ b/custom_components/dreame_mower/translations/ru.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Вернуться на базу без остановки задачи"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Высота скашивания"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/sv.json
+++ b/custom_components/dreame_mower/translations/sv.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Docka utan att stoppa uppgiften"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Klipphöjd"
+      }
     }
   }
 }

--- a/custom_components/dreame_mower/translations/uk.json
+++ b/custom_components/dreame_mower/translations/uk.json
@@ -162,6 +162,11 @@
       "dock_without_stopping": {
         "name": "Повернутися на базу без зупинки завдання"
       }
+    },
+    "number": {
+      "cutting_height": {
+        "name": "Висота скошування"
+      }
     }
   }
 }

--- a/dev/device_cli.py
+++ b/dev/device_cli.py
@@ -11,6 +11,10 @@ Examples:
   .venv/bin/python dev/device_cli.py set-map --map-id 2 --watch-seconds 5
   .venv/bin/python dev/device_cli.py start-mode --mode zone --zone-id 3
     .venv/bin/python dev/device_cli.py start-mode --mode spot --spot-area-id 2
+  .venv/bin/python dev/device_cli.py cutting-height
+    .venv/bin/python dev/device_cli.py cutting-height --set 5.5 --map-id 2
+    .venv/bin/python dev/device_cli.py cutting-height --set 4 --zone-id 3
+    .venv/bin/python dev/device_cli.py cutting-height --mode map_wide
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+from custom_components.dreame_mower.dreame.const import MowingPreferenceMode
 from custom_components.dreame_mower.dreame.device import DreameMowerDevice, MowingMode
 
 VALID_COUNTRIES = ["eu", "cn", "us", "ru", "sg"]
@@ -181,6 +186,8 @@ def build_device_snapshot(
         "status_code": device.status_code,
         "bluetooth_connected": device.bluetooth_connected,
         "current_map_id": device.current_map_id,
+        "cutting_height_cm": device.cutting_height,
+        "zone_cutting_heights_cm": device.zone_cutting_heights,
         "task_target_map_id": device.task_target_map_id,
         "maps": device.available_maps,
         "task_data": device.current_task_data,
@@ -260,6 +267,37 @@ def build_parser() -> argparse.ArgumentParser:
     start_mode_parser.add_argument("--zone-id", type=int, action="append", default=[])
     start_mode_parser.add_argument("--contour-id", type=parse_contour_id, action="append", default=[])
     start_mode_parser.add_argument("--spot-area-id", type=int, action="append", default=[])
+
+    cutting_height_parser = subparsers.add_parser(
+        "cutting-height",
+        help="Read or set the map-wide cutting height",
+    )
+    add_common_args(cutting_height_parser)
+    cutting_height_parser.add_argument(
+        "--set",
+        dest="height",
+        type=float,
+        default=None,
+        help="Cutting height in cm to write; omit to only read the current value",
+    )
+    cutting_height_parser.add_argument("--map-id", type=int, default=None)
+    cutting_height_parser.add_argument(
+        "--zone-id",
+        type=int,
+        default=None,
+        help="Target a single zone instead of the whole map",
+    )
+    cutting_height_parser.add_argument(
+        "--mode",
+        choices=[mode.name.lower() for mode in MowingPreferenceMode],
+        default=None,
+        help="Switch the map between its map-wide and per-zone preferences",
+    )
+    cutting_height_parser.add_argument(
+        "--skip-map-fetch",
+        action="store_true",
+        help="Do not load vector map metadata before addressing the map",
+    )
 
     pause_parser = subparsers.add_parser("pause", help="Pause the mower")
     add_common_args(pause_parser)
@@ -357,6 +395,31 @@ async def run_command(device: DreameMowerDevice, args: argparse.Namespace) -> di
             "ok": success,
             "command": args.command,
             "mode": args.mode,
+            "state": build_device_snapshot(device),
+        }
+
+    if args.command == "cutting-height":
+        fetched_before = None if args.skip_map_fetch else await fetch_vector_map_async(device)
+        applied = None
+        if args.mode is not None:
+            applied = await device.set_mowing_preference_mode(
+                MowingPreferenceMode[args.mode.upper()], args.map_id
+            )
+        if args.height is not None:
+            applied = await device.set_cutting_height(args.height, args.map_id, args.zone_id)
+        current_height = await device.refresh_cutting_height(args.map_id)
+        zone_heights = await device.refresh_zone_cutting_heights(args.map_id)
+        mode = device.mowing_preference_mode
+        return {
+            "ok": applied if applied is not None else current_height is not None,
+            "command": args.command,
+            "map_fetched_before": fetched_before,
+            "requested_map_id": args.map_id,
+            "requested_zone_id": args.zone_id,
+            "requested_height_cm": args.height,
+            "cutting_height_cm": current_height,
+            "zone_cutting_heights_cm": zone_heights,
+            "mowing_preference_mode": mode.name.lower() if mode is not None else None,
             "state": build_device_snapshot(device),
         }
 

--- a/tests/custom_components/dreame_mower/dreame/test_const.py
+++ b/tests/custom_components/dreame_mower/dreame/test_const.py
@@ -4,9 +4,13 @@ import pytest
 from homeassistant.components.lawn_mower import LawnMowerActivity
 
 from custom_components.dreame_mower.dreame.const import (
+    CUTTING_HEIGHT_ABSOLUTE_MAX_CM,
+    CUTTING_HEIGHT_DEFAULT_MAX_CM,
     DeviceStatus,
     STATUS_MAPPING,
+    cutting_height_max_cm,
     map_status_to_activity,
+    supports_cutting_height,
 )
 
 
@@ -49,3 +53,29 @@ class TestStatusMapping:
 
     def test_maintenance_paused(self):
         assert STATUS_MAPPING[DeviceStatus.MAINTENANCE_PAUSED] == "maintenance_paused"
+
+
+class TestCuttingHeightSupport:
+    """Test the model-dependent cutting height helpers."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["dreame.mower.g2408", "dreame.mower.p2255", "dreame.mower.g2541e", "mova.mower.g2529b"],
+    )
+    def test_adjustable_models_are_supported(self, model):
+        assert supports_cutting_height(model) is True
+
+    @pytest.mark.parametrize("model", ["mova.mower.g2405a", "mova.mower.g2405c"])
+    def test_fixed_height_models_are_unsupported(self, model):
+        assert supports_cutting_height(model) is False
+
+    def test_default_models_top_out_at_seven_centimeters(self):
+        assert cutting_height_max_cm("dreame.mower.g2408") == CUTTING_HEIGHT_DEFAULT_MAX_CM
+
+    @pytest.mark.parametrize("model", ["dreame.mower.g2541e", "mova.mower.g2529b"])
+    def test_extended_models_top_out_at_ten_centimeters(self, model):
+        assert cutting_height_max_cm(model) == CUTTING_HEIGHT_ABSOLUTE_MAX_CM
+
+    def test_unknown_models_fall_back_to_the_default_range(self):
+        assert supports_cutting_height("dreame.mower.x9999") is True
+        assert cutting_height_max_cm("dreame.mower.x9999") == CUTTING_HEIGHT_DEFAULT_MAX_CM

--- a/tests/custom_components/dreame_mower/dreame/test_device.py
+++ b/tests/custom_components/dreame_mower/dreame/test_device.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, Mock, patch, PropertyMock
 from custom_components.dreame_mower.dreame.device import DreameMowerDevice, MowingMode
 from custom_components.dreame_mower.dreame.const import (
     DeviceStatus,
+    MowingPreferenceMode,
     ONLINE_OFFLINE_DEBOUNCE_POLLS,
 )
 
@@ -1883,3 +1884,487 @@ def test_incoming_message_restores_online(device):
 
     assert device.online is True
     assert ("online", True) in notified
+
+
+# A full mowing preference record as reported for a map-wide (area 0) entry.
+# Slot 4 carries the cutting height in millimeters, so this record is 6 cm.
+_MOWING_PREFERENCE_RECORD = [3, 0, 0, 1, 60, 0, 180, 1, 0, 1, 1, 1, 1, 20, 20, 7, 1]
+
+
+def _mowing_preference_responder(record=None, *, reject_full_record=False):
+    """Build an action responder that serves mowing preference reads and writes."""
+    served_record = list(_MOWING_PREFERENCE_RECORD if record is None else record)
+    writes: list[list[int]] = []
+
+    def responder(siid, aiid, parameters, retry_count):
+        payload = parameters[0]
+        if payload["m"] == "g":
+            return {"code": 0, "out": [{"r": 0, "d": list(served_record)}]}
+
+        writes.append(list(payload["d"]))
+        if reject_full_record and len(writes) == 1:
+            return {"code": 0, "out": [{"r": -3}]}
+        return {"code": 0, "out": [{"r": 0}]}
+
+    return responder, writes
+
+
+def _load_two_map_vector_map(device):
+    """Attach a two-map vector map and make map 1 the current map."""
+    device._vector_map = SimpleNamespace(
+        available_maps=[
+            SimpleNamespace(map_id=1, map_index=0, name="Front", total_area=25.0),
+            SimpleNamespace(map_id=2, map_index=1, name="Back", total_area=30.5),
+        ]
+    )
+    device._current_map_id = 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_cutting_height_reads_the_map_wide_record(device):
+    """Reading the height should query area 0 of the current map's record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, _ = _mowing_preference_responder()
+
+    height = await device.refresh_cutting_height()
+
+    assert height == 6.0
+    assert device.cutting_height == 6.0
+    _, _, parameters, _ = device._cloud_device.action_calls[0]
+    assert parameters == [{"m": "g", "t": "PRE", "d": {"idx": 0, "region": 0}}]
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_writes_back_the_record_with_only_the_height_changed(device):
+    """Setting the height must preserve every other slot of the record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, writes = _mowing_preference_responder()
+
+    result = await device.set_cutting_height(4.5)
+
+    assert result is True
+    assert len(writes) == 1
+    expected_record = list(_MOWING_PREFERENCE_RECORD)
+    expected_record[0] = 0  # version is zeroed on write
+    expected_record[1] = 0  # map index of map ID 1
+    expected_record[2] = 0  # map-wide area ID
+    expected_record[4] = 45
+    assert writes[0] == expected_record
+    assert device.cutting_height == 4.5
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_targets_the_requested_map(device):
+    """An explicit map ID should address that map without touching the cached height."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, writes = _mowing_preference_responder()
+
+    result = await device.set_cutting_height(7, map_id=2)
+
+    assert result is True
+    _, _, read_parameters, _ = device._cloud_device.action_calls[0]
+    assert read_parameters == [{"m": "g", "t": "PRE", "d": {"idx": 1, "region": 0}}]
+    assert writes[0][1] == 1
+    assert writes[0][4] == 70
+    assert device.cutting_height is None
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_retries_with_the_short_record(device):
+    """A record the firmware rejects should be retried without its trailing slots."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, writes = _mowing_preference_responder(reject_full_record=True)
+
+    result = await device.set_cutting_height(5)
+
+    assert result is True
+    assert len(writes) == 2
+    assert len(writes[0]) == 17
+    assert writes[1] == writes[0][:16]
+    assert device.cutting_height == 5.0
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_fails_when_the_record_cannot_be_read(device):
+    """Without the current record there is nothing safe to write back."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result = {"code": 0, "out": [{"r": -1}]}
+
+    result = await device.set_cutting_height(5)
+
+    assert result is False
+    assert len(device._cloud_device.action_calls) == 1
+    assert device.cutting_height is None
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_rejects_heights_outside_the_supported_range(device):
+    """Heights the protocol cannot carry should be rejected before any request."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, _ = _mowing_preference_responder()
+
+    with pytest.raises(ValueError):
+        await device.set_cutting_height(2.5)
+    with pytest.raises(ValueError):
+        await device.set_cutting_height(12)
+
+    assert len(device._cloud_device.action_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_rejects_unknown_map_ids(device):
+    """An unknown map ID should be rejected instead of writing to another map."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, _ = _mowing_preference_responder()
+
+    result = await device.set_cutting_height(5, map_id=9)
+
+    assert result is False
+    assert len(device._cloud_device.action_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_snaps_to_half_centimeter_steps(device):
+    """Heights between steps should snap to the nearest settable value."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, writes = _mowing_preference_responder()
+
+    result = await device.set_cutting_height(5.3)
+
+    assert result is True
+    assert writes[0][4] == 55
+    assert device.cutting_height == 5.5
+
+
+@pytest.mark.asyncio
+async def test_cutting_height_change_notifies_property_callbacks(device):
+    """A changed height should be pushed to registered property callbacks."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_two_map_vector_map(device)
+    device._cloud_device.action_result, _ = _mowing_preference_responder()
+    notified = []
+    device.register_property_callback(lambda name, value: notified.append((name, value)))
+
+    await device.refresh_cutting_height()
+
+    assert ("cutting_height", 6.0) in notified
+
+
+def _preference_responder(
+    *,
+    mode=0,
+    configured_area_ids=(0,),
+    records=None,
+    reject_full_record=False,
+):
+    """Build an action responder that serves the full preference protocol.
+
+    Reads of an area without a record fail the way the device reports a missing
+    record, and writes are collected so tests can assert on them.
+    """
+    stored_records = {0: list(_MOWING_PREFERENCE_RECORD)}
+    stored_records.update({int(k): list(v) for k, v in (records or {}).items()})
+    available_area_ids = set(configured_area_ids)
+    calls: dict[str, list] = {"writes": [], "modes": []}
+
+    def responder(siid, aiid, parameters, retry_count):
+        payload = parameters[0]
+        if payload.get("t") not in ("PRE", "PREI", "PREP"):
+            return {"code": 0, "out": [{"r": 0}]}
+
+        if payload["t"] == "PREI":
+            return {
+                "code": 0,
+                "out": [{"r": 0, "d": {"type": mode, "ver": [[area_id, 1] for area_id in sorted(available_area_ids)]}}],
+            }
+
+        if payload["t"] == "PREP":
+            calls["modes"].append(payload["d"])
+            return {"code": 0, "out": [{"r": 0}]}
+
+        if payload["m"] == "g":
+            area_id = payload["d"]["region"]
+            if area_id not in available_area_ids:
+                return {"code": 0, "out": [{"r": -1}]}
+            return {"code": 0, "out": [{"r": 0, "d": list(stored_records[area_id])}]}
+
+        record = list(payload["d"])
+        calls["writes"].append(record)
+        if reject_full_record and len(calls["writes"]) == 1:
+            return {"code": 0, "out": [{"r": -3}]}
+        stored_records[record[2]] = record
+        available_area_ids.add(record[2])
+        return {"code": 0, "out": [{"r": 0}]}
+
+    return responder, calls
+
+
+def _load_zoned_vector_map(device):
+    """Attach a vector map with two maps, the current one carrying three zones."""
+    device._vector_map = SimpleNamespace(
+        available_maps=[
+            SimpleNamespace(map_id=1, map_index=0, name="Front", total_area=25.0),
+            SimpleNamespace(map_id=2, map_index=1, name="Back", total_area=30.5),
+        ],
+        zones=[
+            SimpleNamespace(zone_id=1, name="Lawn", area=12.5),
+            SimpleNamespace(zone_id=2, name="Orchard", area=8.0),
+            SimpleNamespace(zone_id=3, name="Slope", area=5.0),
+        ],
+    )
+    device._current_map_id = 1
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_writes_a_record_for_that_zone(device):
+    """A zone height should be written to the zone's own record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder()
+
+    result = await device.set_cutting_height(4.0, zone_id=2)
+
+    assert result is True
+    zone_write = next(write for write in calls["writes"] if write[2] == 2)
+    assert zone_write[4] == 40
+    assert zone_write[1] == 0  # map index of the current map
+    assert device.zone_cutting_heights == {2: 4.0}
+    assert device.cutting_height is None
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_starts_from_the_zone_record_when_it_exists(device):
+    """An existing zone record must be preserved rather than replaced wholesale."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    zone_record = list(_MOWING_PREFERENCE_RECORD)
+    zone_record[3] = 0  # a zone-specific efficiency mode
+    zone_record[13] = 5  # a zone-specific obstacle setting
+    device._cloud_device.action_result, calls = _preference_responder(
+        mode=1,
+        configured_area_ids=(0, 2),
+        records={2: zone_record},
+    )
+
+    result = await device.set_cutting_height(6.5, zone_id=2)
+
+    assert result is True
+    assert len(calls["writes"]) == 1
+    assert calls["writes"][0][3] == 0
+    assert calls["writes"][0][13] == 5
+    assert calls["writes"][0][4] == 65
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_switches_the_map_to_per_zone_preferences(device):
+    """A zone height has no effect while the map applies its map-wide record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder(mode=0)
+
+    result = await device.set_cutting_height(4.0, zone_id=2)
+
+    assert result is True
+    assert calls["modes"] == [{"idx": 0, "value": 1}]
+    assert device.mowing_preference_mode == MowingPreferenceMode.PER_ZONE
+
+
+@pytest.mark.asyncio
+async def test_switching_to_per_zone_preferences_seeds_untouched_zones(device):
+    """Zones without a record of their own must keep the map-wide settings."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder(mode=0)
+
+    await device.set_cutting_height(4.0, zone_id=2)
+
+    seeded_area_ids = {write[2] for write in calls["writes"]}
+    assert seeded_area_ids == {1, 2, 3}
+    for write in calls["writes"]:
+        if write[2] == 2:
+            continue
+        assert write[4] == _MOWING_PREFERENCE_RECORD[4]
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_leaves_an_already_per_zone_map_alone(device):
+    """A map already using its per-zone records needs no mode change or seeding."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder(mode=1)
+
+    result = await device.set_cutting_height(4.0, zone_id=2)
+
+    assert result is True
+    assert calls["modes"] == []
+    assert [write[2] for write in calls["writes"]] == [2]
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_rejects_unknown_zone_ids(device):
+    """An unknown zone should be rejected instead of creating a stray record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder()
+
+    result = await device.set_cutting_height(4.0, zone_id=9)
+
+    assert result is False
+    assert calls["writes"] == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_zone_cutting_heights_reads_every_configured_zone(device):
+    """Reading should report the height of each zone that has its own record."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    zone_one = list(_MOWING_PREFERENCE_RECORD)
+    zone_one[4] = 35
+    zone_three = list(_MOWING_PREFERENCE_RECORD)
+    zone_three[4] = 70
+    device._cloud_device.action_result, _ = _preference_responder(
+        mode=1,
+        configured_area_ids=(0, 1, 3),
+        records={1: zone_one, 3: zone_three},
+    )
+
+    zone_heights = await device.refresh_zone_cutting_heights()
+
+    assert zone_heights == {1: 3.5, 3: 7.0}
+    assert device.zone_cutting_heights == {1: 3.5, 3: 7.0}
+    assert device.mowing_preference_mode == MowingPreferenceMode.PER_ZONE
+
+
+@pytest.mark.asyncio
+async def test_set_mowing_preference_mode_switches_back_to_the_map_wide_record(device):
+    """Switching back should send the mode command and cache the new mode."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder(mode=1)
+
+    result = await device.set_mowing_preference_mode(MowingPreferenceMode.MAP_WIDE)
+
+    assert result is True
+    assert calls["modes"] == [{"idx": 0, "value": 0}]
+    assert device.mowing_preference_mode == MowingPreferenceMode.MAP_WIDE
+
+
+@pytest.mark.asyncio
+async def test_switching_the_current_map_drops_the_cached_heights(device):
+    """The cached heights describe one map, so a map switch must clear them."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, _ = _preference_responder(mode=1)
+    await device.refresh_cutting_height()
+    await device.set_cutting_height(4.0, zone_id=2)
+    assert device.cutting_height is not None
+    assert device.zone_cutting_heights
+
+    await device.set_current_map(2)
+
+    assert device.cutting_height is None
+    assert device.zone_cutting_heights == {}
+    assert device.mowing_preference_mode is None
+
+
+def _load_multi_zone_vector_map(device):
+    """Attach geometry where each map carries its own distinct set of zones."""
+    map_one = SimpleNamespace(zones=[SimpleNamespace(zone_id=1, name="Lawn", area=12.5)])
+    map_two = SimpleNamespace(zones=[SimpleNamespace(zone_id=7, name="Cellar", area=4.0)])
+    device._vector_map = SimpleNamespace(
+        available_maps=[
+            SimpleNamespace(map_id=1, map_index=0, name="Front", total_area=25.0),
+            SimpleNamespace(map_id=2, map_index=1, name="Back", total_area=30.5),
+        ],
+        zones=map_one.zones,
+        maps={1: map_one, 2: map_two},
+    )
+    device._current_map_id = 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_mowing_preference_mode_reads_and_caches_the_mode(device):
+    """The mode decides which heights apply, so it must be readable on its own."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, _ = _preference_responder(mode=1)
+
+    mode = await device.refresh_mowing_preference_mode()
+
+    assert mode == MowingPreferenceMode.PER_ZONE
+    assert device.mowing_preference_mode == MowingPreferenceMode.PER_ZONE
+    _, _, parameters, _ = device._cloud_device.action_calls[0]
+    assert parameters == [{"m": "g", "t": "PREI", "d": {"idx": 0}}]
+
+
+@pytest.mark.asyncio
+async def test_refresh_mowing_preference_mode_does_not_cache_another_map(device):
+    """The cache describes the current map, so another map's mode must not land in it."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_zoned_vector_map(device)
+    device._cloud_device.action_result, _ = _preference_responder(mode=1)
+
+    mode = await device.refresh_mowing_preference_mode(map_id=2)
+
+    assert mode == MowingPreferenceMode.PER_ZONE
+    assert device.mowing_preference_mode is None
+    _, _, parameters, _ = device._cloud_device.action_calls[0]
+    assert parameters == [{"m": "g", "t": "PREI", "d": {"idx": 1}}]
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_validates_against_the_targeted_map(device):
+    """Zone validation must use the target map's zones, not the active map's."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_multi_zone_vector_map(device)
+    device._cloud_device.action_result, calls = _preference_responder(mode=1)
+
+    assert await device.set_cutting_height(4.0, map_id=2, zone_id=7) is True
+    assert [write[2] for write in calls["writes"]] == [7]
+    assert calls["writes"][0][1] == 1  # map index of map ID 2
+
+    # Zone 1 exists on the active map but not on map 2.
+    assert await device.set_cutting_height(4.0, map_id=2, zone_id=1) is False
+    assert len(calls["writes"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_set_zone_cutting_height_defers_when_the_map_geometry_is_unknown(device):
+    """Without geometry for a map the device has to be the one to reject the zone."""
+    device._cloud_device.set_connected_state(True)
+    await device.connect()
+    _load_multi_zone_vector_map(device)
+    del device._vector_map.maps[2]
+    device._cloud_device.action_result, calls = _preference_responder(mode=1)
+
+    assert await device.set_cutting_height(4.0, map_id=2, zone_id=99) is True
+    assert [write[2] for write in calls["writes"]] == [99]

--- a/tests/custom_components/dreame_mower/test_coordinator.py
+++ b/tests/custom_components/dreame_mower/test_coordinator.py
@@ -1,5 +1,7 @@
 """Test the Dreame Mower coordinator."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_USERNAME
@@ -8,6 +10,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.dreame_mower.coordinator import DreameMowerCoordinator
 from custom_components.dreame_mower.const import DOMAIN
 from custom_components.dreame_mower.config_flow import CONF_ACCOUNT_TYPE, CONF_COUNTRY, CONF_DID, CONF_MAC, CONF_MODEL, CONF_SERIAL
+from custom_components.dreame_mower.dreame.const import (
+    CURRENT_MAP_ID_PROPERTY_NAME,
+    MowingPreferenceMode,
+)
 
 
 @pytest.fixture
@@ -107,3 +113,81 @@ async def test_coordinator_with_required_config_data(hass: HomeAssistant):
     
     # Should use provided name from config
     assert data["name"] == "Test Required Mower"
+
+async def test_coordinator_refreshes_the_cutting_height_when_the_map_changes(
+    hass: HomeAssistant, minimal_config_entry
+):
+    """The height is stored per map, so a map switch must re-read it."""
+    coordinator = DreameMowerCoordinator(hass, entry=minimal_config_entry)
+    coordinator.device.refresh_cutting_height = AsyncMock(return_value=5.0)
+
+    coordinator._handle_device_update(CURRENT_MAP_ID_PROPERTY_NAME, 2)
+    await hass.async_block_till_done()
+
+    coordinator.device.refresh_cutting_height.assert_awaited_once()
+
+
+async def test_coordinator_skips_the_cutting_height_refresh_for_fixed_height_models(
+    hass: HomeAssistant, minimal_config_entry
+):
+    """Models without an adjustable height should not be queried for it."""
+    minimal_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        minimal_config_entry,
+        data={**minimal_config_entry.data, CONF_MODEL: "mova.mower.g2405c"},
+    )
+    coordinator = DreameMowerCoordinator(hass, entry=minimal_config_entry)
+    coordinator.device.refresh_cutting_height = AsyncMock(return_value=None)
+
+    coordinator._handle_device_update(CURRENT_MAP_ID_PROPERTY_NAME, 2)
+    await hass.async_block_till_done()
+
+    coordinator.device.refresh_cutting_height.assert_not_awaited()
+
+
+async def test_coordinator_delegates_cutting_height_calls_to_the_device(
+    hass: HomeAssistant, minimal_config_entry
+):
+    """Entity tests mock the coordinator, so its own wiring needs covering here."""
+    coordinator = DreameMowerCoordinator(hass, entry=minimal_config_entry)
+    device = MagicMock()
+    device.cutting_height = 4.0
+    device.zone_cutting_heights = {1: 5.0}
+    device.mowing_preference_mode = MowingPreferenceMode.PER_ZONE
+    device.set_cutting_height = AsyncMock(return_value=True)
+    device.set_mowing_preference_mode = AsyncMock(return_value=True)
+    device.refresh_cutting_height = AsyncMock(return_value=4.0)
+    device.refresh_zone_cutting_heights = AsyncMock(return_value={1: 5.0})
+    coordinator.device = device
+    coordinator.async_update_listeners = MagicMock()
+
+    assert coordinator.cutting_height == 4.0
+    assert coordinator.zone_cutting_heights == {1: 5.0}
+    assert coordinator.mowing_preference_mode is MowingPreferenceMode.PER_ZONE
+
+    assert await coordinator.async_set_cutting_height(5.5, 2, 3) is True
+    device.set_cutting_height.assert_awaited_once_with(5.5, 2, 3)
+
+    assert await coordinator.async_set_mowing_preference_mode(MowingPreferenceMode.MAP_WIDE, 2) is True
+    device.set_mowing_preference_mode.assert_awaited_once_with(MowingPreferenceMode.MAP_WIDE, 2)
+
+    assert await coordinator.async_fetch_zone_cutting_heights() == {1: 5.0}
+    await coordinator.async_fetch_cutting_heights()
+    assert device.refresh_cutting_height.await_count == 1
+    assert device.refresh_zone_cutting_heights.await_count == 2
+
+    # Every one of those calls has to push the new state to the entities.
+    assert coordinator.async_update_listeners.call_count == 4
+
+
+async def test_coordinator_cutting_height_defaults_to_the_current_map_and_whole_map(
+    hass: HomeAssistant, minimal_config_entry
+):
+    """Omitted map and zone must reach the device as None, not be dropped."""
+    coordinator = DreameMowerCoordinator(hass, entry=minimal_config_entry)
+    coordinator.device = MagicMock()
+    coordinator.device.set_cutting_height = AsyncMock(return_value=True)
+
+    await coordinator.async_set_cutting_height(6.0)
+
+    coordinator.device.set_cutting_height.assert_awaited_once_with(6.0, None, None)

--- a/tests/custom_components/dreame_mower/test_init.py
+++ b/tests/custom_components/dreame_mower/test_init.py
@@ -39,18 +39,34 @@ def _make_entry() -> MockConfigEntry:
     )
 
 
-async def test_async_setup_entry_fetches_vector_map_for_mowers(hass):
-    """Mower setup should preload vector map data before entity setup."""
-    entry = _make_entry()
-    entry.add_to_hass(hass)
+def _make_coordinator() -> MagicMock:
+    """Build a mower coordinator stub whose awaited calls are real coroutines.
 
+    Every method setup awaits has to be an AsyncMock: a bare MagicMock would
+    raise TypeError, which setup swallows, so the assertions below would pass
+    without the call ever having happened.
+    """
     coordinator = MagicMock()
     coordinator.device_type = "mower"
+    coordinator.supports_cutting_height = True
     coordinator.device = MagicMock()
     coordinator.device.fetch_vector_map = MagicMock(return_value=True)
     coordinator.async_connect_device = AsyncMock(return_value=True)
     coordinator.async_config_entry_first_refresh = AsyncMock(return_value=None)
     coordinator.async_request_refresh = AsyncMock(return_value=None)
+    coordinator.async_fetch_consumable_data = AsyncMock(return_value=None)
+    coordinator.async_fetch_cutting_heights = AsyncMock(return_value=None)
+    coordinator.async_fetch_firmware_status = AsyncMock(return_value=None)
+    coordinator.async_update_online_status = AsyncMock(return_value=None)
+    return coordinator
+
+
+async def test_async_setup_entry_fetches_vector_map_for_mowers(hass):
+    """Mower setup should preload vector map data before entity setup."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    coordinator = _make_coordinator()
 
     with patch("custom_components.dreame_mower.DreameMowerCoordinator", return_value=coordinator), patch.object(
         hass.config_entries,
@@ -63,8 +79,27 @@ async def test_async_setup_entry_fetches_vector_map_for_mowers(hass):
     coordinator.device.fetch_vector_map.assert_called_once_with()
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
     coordinator.async_request_refresh.assert_awaited_once()
+    coordinator.async_fetch_cutting_heights.assert_awaited_once()
     forward_entry_setups.assert_awaited_once()
     assert hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] is coordinator
+
+
+async def test_async_setup_entry_skips_the_cutting_height_for_fixed_height_models(hass):
+    """Models with a manual height dial must not be queried for one."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    coordinator = _make_coordinator()
+    coordinator.supports_cutting_height = False
+
+    with patch("custom_components.dreame_mower.DreameMowerCoordinator", return_value=coordinator), patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        AsyncMock(return_value=None),
+    ):
+        assert await async_setup_entry(hass, entry) is True
+
+    coordinator.async_fetch_cutting_heights.assert_not_awaited()
 
 
 async def test_async_setup_entry_raises_not_ready_on_connect_failure(hass):

--- a/tests/custom_components/dreame_mower/test_lawn_mower.py
+++ b/tests/custom_components/dreame_mower/test_lawn_mower.py
@@ -7,7 +7,11 @@ from homeassistant.components.lawn_mower import LawnMowerActivity
 from homeassistant.exceptions import HomeAssistantError
 from custom_components.dreame_mower.dreame.device import MowingMode
 from custom_components.dreame_mower.lawn_mower import DreameMowerLawnMower
-from custom_components.dreame_mower.dreame.const import STATUS_PROPERTY, DeviceStatus
+from custom_components.dreame_mower.dreame.const import (
+    STATUS_PROPERTY,
+    DeviceStatus,
+    MowingPreferenceMode,
+)
 
 
 def _make_coordinator(connected=True, status_code=0):
@@ -40,6 +44,12 @@ def _make_coordinator(connected=True, status_code=0):
     coordinator.device.start_mowing_spots = AsyncMock(return_value=True)
     coordinator.device.start_mowing_generic = AsyncMock(return_value=True)
     coordinator.device.mowing_session_active = False
+    coordinator.supports_cutting_height = True
+    coordinator.cutting_height = None
+    coordinator.zone_cutting_heights = {}
+    coordinator.mowing_preference_mode = None
+    coordinator.async_set_cutting_height = AsyncMock(return_value=True)
+    coordinator.async_set_mowing_preference_mode = AsyncMock(return_value=True)
     return coordinator
 
 
@@ -351,8 +361,155 @@ def test_extra_state_attributes_include_zones_and_contours():
         "maps": [{"id": 1, "index": 0, "name": "Front", "area": 12.5}],
         "current_map_id": 1,
         "task_target_map_id": 2,
+        "cutting_height": None,
+        "zone_cutting_heights": {},
+        "mowing_preference_mode": None,
         "selected_mowing_mode": "all_area",
         "selected_contour_id": [2, 0],
         "selected_zone_id": 1,
         "selected_spot_area_id": 4,
     }
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_delegates_to_the_coordinator():
+    """The service should forward the height and optional map to the coordinator."""
+    coordinator = _make_coordinator()
+    entity = _make_entity(coordinator)
+
+    await entity.async_set_cutting_height(4.5, map_id=2)
+
+    coordinator.async_set_cutting_height.assert_awaited_once_with(4.5, 2, None)
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_defaults_to_the_active_map():
+    """Omitting the map should let the device layer use the active map."""
+    coordinator = _make_coordinator()
+    entity = _make_entity(coordinator)
+
+    await entity.async_set_cutting_height(6)
+
+    coordinator.async_set_cutting_height.assert_awaited_once_with(6, None, None)
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_rejects_fixed_height_models():
+    """Models without an adjustable height should report a clear error."""
+    coordinator = _make_coordinator()
+    coordinator.supports_cutting_height = False
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_cutting_height(5)
+
+    coordinator.async_set_cutting_height.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_raises_when_the_write_fails():
+    """A failed write should surface as an error instead of passing silently."""
+    coordinator = _make_coordinator()
+    coordinator.async_set_cutting_height = AsyncMock(return_value=False)
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_cutting_height(5)
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_reports_out_of_range_heights():
+    """A height the device layer rejects should surface as an error."""
+    coordinator = _make_coordinator()
+    coordinator.async_set_cutting_height = AsyncMock(side_effect=ValueError("out of range"))
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_cutting_height(99)
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_forwards_the_zone_id():
+    """A zone ID should reach the coordinator so only that zone changes."""
+    coordinator = _make_coordinator()
+    entity = _make_entity(coordinator)
+
+    await entity.async_set_cutting_height(5.0, zone_id=3)
+
+    coordinator.async_set_cutting_height.assert_awaited_once_with(5.0, None, 3)
+
+
+@pytest.mark.asyncio
+async def test_set_cutting_height_service_names_the_zone_when_it_fails():
+    """A failed zone write should say which zone it was."""
+    coordinator = _make_coordinator()
+    coordinator.async_set_cutting_height = AsyncMock(return_value=False)
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError, match="zone 3"):
+        await entity.async_set_cutting_height(5.0, zone_id=3)
+
+
+@pytest.mark.asyncio
+async def test_set_mowing_preference_mode_service_maps_the_name_to_the_mode():
+    """The service takes a readable mode name and forwards the enum."""
+    coordinator = _make_coordinator()
+    entity = _make_entity(coordinator)
+
+    await entity.async_set_mowing_preference_mode("map_wide", map_id=2)
+
+    coordinator.async_set_mowing_preference_mode.assert_awaited_once_with(
+        MowingPreferenceMode.MAP_WIDE, 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_mowing_preference_mode_service_rejects_fixed_height_models():
+    """Models without adjustable settings should report a clear error."""
+    coordinator = _make_coordinator()
+    coordinator.supports_cutting_height = False
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_mowing_preference_mode("per_zone")
+
+    coordinator.async_set_mowing_preference_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_mowing_preference_mode_service_raises_when_the_switch_fails():
+    """A rejected mode switch should surface as an error."""
+    coordinator = _make_coordinator()
+    coordinator.async_set_mowing_preference_mode = AsyncMock(return_value=False)
+    entity = _make_entity(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_mowing_preference_mode("per_zone")
+
+
+def test_attributes_expose_the_cutting_heights_and_mode():
+    """Automations need the zone IDs and the mode to use the service."""
+    coordinator = _make_coordinator()
+    coordinator.cutting_height = 4.0
+    coordinator.zone_cutting_heights = {1: 5.0, 3: 6.5}
+    coordinator.mowing_preference_mode = MowingPreferenceMode.PER_ZONE
+    entity = _make_entity(coordinator)
+
+    attributes = entity.extra_state_attributes
+
+    assert attributes["cutting_height"] == 4.0
+    assert attributes["zone_cutting_heights"] == {1: 5.0, 3: 6.5}
+    assert attributes["mowing_preference_mode"] == "per_zone"
+
+
+def test_attributes_omit_the_cutting_height_for_fixed_height_models():
+    """Models without an adjustable height should not advertise one."""
+    coordinator = _make_coordinator()
+    coordinator.supports_cutting_height = False
+    entity = _make_entity(coordinator)
+
+    attributes = entity.extra_state_attributes
+
+    assert "cutting_height" not in attributes
+    assert "zone_cutting_heights" not in attributes
+    assert "mowing_preference_mode" not in attributes

--- a/tests/custom_components/dreame_mower/test_number.py
+++ b/tests/custom_components/dreame_mower/test_number.py
@@ -1,0 +1,112 @@
+"""Tests for Dreame Mower number entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.dreame_mower.const import DATA_COORDINATOR, DOMAIN
+from custom_components.dreame_mower.number import (
+    DreameMowerCuttingHeightNumber,
+    async_setup_entry,
+)
+
+
+def _make_coordinator(model="dreame.mower.g2408"):
+    coordinator = MagicMock()
+    coordinator.device_mac = "AA:BB:CC:DD:EE:FF"
+    coordinator.device_name = "Test Mower"
+    coordinator.device_model = model
+    coordinator.device_serial = "SN123"
+    coordinator.device_manufacturer = "Dreametech™"
+    coordinator.device_firmware = "1.0.0"
+    coordinator.device_connected = True
+    coordinator.device_online = True
+    coordinator.supports_cutting_height = model != "mova.mower.g2405c"
+    coordinator.cutting_height = 5.5
+    coordinator.async_set_cutting_height = AsyncMock(return_value=True)
+    return coordinator
+
+
+def _make_cutting_height_number(coordinator=None):
+    coordinator = coordinator or _make_coordinator()
+    entity = DreameMowerCuttingHeightNumber(coordinator)
+    entity.hass = MagicMock()
+    return entity
+
+
+async def _setup_entry(coordinator):
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entry_id": {DATA_COORDINATOR: coordinator}}}
+    entry = MagicMock()
+    entry.entry_id = "entry_id"
+    added_entities = []
+    await async_setup_entry(hass, entry, added_entities.extend)
+    return added_entities
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_the_cutting_height_entity_for_adjustable_models():
+    """Models with an adjustable cutting height should get the entity."""
+    entities = await _setup_entry(_make_coordinator())
+
+    assert len(entities) == 1
+    assert isinstance(entities[0], DreameMowerCuttingHeightNumber)
+
+
+@pytest.mark.asyncio
+async def test_setup_skips_models_without_an_adjustable_cutting_height():
+    """Models whose height is set by hand should not get the entity."""
+    entities = await _setup_entry(_make_coordinator("mova.mower.g2405c"))
+
+    assert entities == []
+
+
+def test_cutting_height_reports_the_coordinator_value():
+    """The entity state should mirror the height the coordinator holds."""
+    entity = _make_cutting_height_number()
+
+    assert entity.native_value == 5.5
+
+
+def test_cutting_height_is_unknown_until_it_has_been_read():
+    """An unread height leaves the entity without a value."""
+    coordinator = _make_coordinator()
+    coordinator.cutting_height = None
+    entity = _make_cutting_height_number(coordinator)
+
+    assert entity.native_value is None
+
+
+def test_cutting_height_range_follows_the_model():
+    """The selectable range should match what the model supports."""
+    assert _make_cutting_height_number().native_max_value == 7.0
+    assert _make_cutting_height_number(
+        _make_coordinator("dreame.mower.g2541e")
+    ).native_max_value == 10.0
+
+    entity = _make_cutting_height_number()
+    assert entity.native_min_value == 3.0
+    assert entity.native_step == 0.5
+
+
+@pytest.mark.asyncio
+async def test_setting_the_cutting_height_delegates_to_the_coordinator():
+    """Writing the entity should forward the height to the coordinator."""
+    coordinator = _make_coordinator()
+    entity = _make_cutting_height_number(coordinator)
+
+    await entity.async_set_native_value(4.0)
+
+    coordinator.async_set_cutting_height.assert_awaited_once_with(4.0)
+
+
+@pytest.mark.asyncio
+async def test_setting_the_cutting_height_raises_when_the_device_rejects_it():
+    """A rejected write should surface as an error instead of passing silently."""
+    coordinator = _make_coordinator()
+    coordinator.async_set_cutting_height = AsyncMock(return_value=False)
+    entity = _make_cutting_height_number(coordinator)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(4.0)


### PR DESCRIPTION
Adds the ability to read and set the cutting height.

Closes #182
Closes #186

## What it does

The mower stores its mowing settings in a preference record per map, and optionally one per zone. A map applies either its map-wide record or its per-zone records, and the cutting height is one field of that record.

- **`number.cutting_height`** — sets the height of the active map, in 0.5 cm steps. Only created for models whose height is adjustable from software; models with a manual dial (MOVA 600/1000) and the Z1 do not get the entity. The range follows the model: 3–7 cm for most, 3–10 cm for the A3 and LiDAX 800 Ultra.
- **`dreame_mower.set_cutting_height`** — same, plus an optional `map_id` to change a map that is not active, and an optional `zone_id` to change a single zone.
- **`dreame_mower.set_mowing_preference_mode`** — switches a map between one map-wide setting and per-zone settings. Setting a zone height switches the map to per-zone automatically, so this is how you go back.
- **Attributes** `cutting_height`, `zone_cutting_heights` and `mowing_preference_mode` on the mower entity, so automations can read the current values and tell which one is in effect.
- **`dev/device_cli.py cutting-height`** for manual testing.

## Notes

A height change is a read-modify-write of the whole record: firmware reports records longer than the fields this integration names, and every untouched field is written back verbatim so unrelated mowing settings are preserved.

Switching a map to per-zone settings first copies the map-wide record into any zone that has none, so zones the user did not touch keep behaving as before.

Heights are stored per map, so the cached value is re-read whenever the active map changes.

## Testing

644 tests, 85% statement coverage on the new code, mypy clean.

Verified against a Dreame A2 with two maps: reading both maps, writing the active and the non-active map, writing a zone, and switching the preference mode, each confirmed in the app and restored afterwards.

Two things remain unverified against hardware and may need adjusting from user reports:

- the 3–10 cm range for the A3 and LiDAX 800 Ultra, and the list of models treated as having a fixed height
- the zone-seeding path when switching a map with several zones to per-zone settings
